### PR TITLE
feat: initial MCP server with 41 OPNsense tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# OPNsense API Configuration
+OPNSENSE_URL=https://10.10.0.1
+OPNSENSE_API_KEY=your-api-key-here
+OPNSENSE_API_SECRET=your-api-secret-here
+
+# SSL Verification (default: true)
+# Set to false for self-signed certificates
+OPNSENSE_VERIFY_SSL=true
+
+# Request timeout in milliseconds (default: 30000)
+OPNSENSE_TIMEOUT=30000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Environment
+.env
+*.env.local
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+
+# Test coverage
+coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
+
+## Unreleased
+
+- Initial project setup
+- OPNsense API client (axios, Basic Auth, SSL)
+- DNS/Unbound tools (12 tools)
+- Firewall tools (8 tools)
+- Diagnostics tools (8 tools)
+- Interface tools (3 tools, read-only)
+- DHCP tools (5 tools, ISC + Kea dual support)
+- System tools (5 tools)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# mcp-opnsense — CLAUDE.md
+
+## Project Overview
+
+Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense REST API. Provides ~41 granular tools for DNS, Firewall, Diagnostics, Interfaces, DHCP, and System management.
+
+**No SSH. No shell execution. API-only.**
+
+## Architecture
+
+```
+src/
+  index.ts                 # MCP Server entry point (stdio transport only)
+  client/
+    opnsense-client.ts     # Axios HTTP client (Basic Auth, SSL, error handling)
+    types.ts               # OPNsense API response types
+  tools/
+    dns.ts                 # 12 DNS/Unbound tools
+    firewall.ts            # 8 Firewall tools
+    diagnostics.ts         # 8 Diagnostics tools
+    interfaces.ts          # 3 Interface tools (read-only)
+    dhcp.ts                # 5 DHCP tools (ISC + Kea dual support)
+    system.ts              # 5 System/Service tools
+  utils/
+    validation.ts          # Shared Zod schemas (IP, UUID, CIDR, etc.)
+    errors.ts              # OPNsense error extraction
+tests/                     # Vitest unit tests
+docs/
+  api-reference.md         # OPNsense API endpoint mapping
+```
+
+## Code Conventions
+
+### TypeScript
+- Strict mode enabled (`"strict": true` in tsconfig.json)
+- All tool parameters validated with Zod schemas
+- Generically typed API client (`get<T>()`, `post<T>()`, `delete<T>()`)
+- No `any` types — use `unknown` and narrow
+
+### Tool Design
+- **Granular tools**: one MCP tool per operation (e.g., `opnsense_dns_add_override`)
+- Tool naming: `opnsense_<domain>_<action>`
+- Each tool has its own Zod input schema and clear description
+- Destructive operations require confirmation parameters
+
+### Dependencies
+- **3 runtime dependencies only**: `@modelcontextprotocol/sdk`, `axios`, `zod`
+- No SSH libraries, no Redis, no PostgreSQL
+- Dev: `typescript`, `vitest`, `@types/node`
+
+## Security
+
+- **Transport**: stdio only (no SSE, no HTTP endpoint)
+- **Authentication**: API Key/Secret via environment variables only
+- **SSL**: Enabled by default, configurable for self-signed certs
+- **No SSH**: Exclusively OPNsense REST API
+- **Input validation**: Zod schemas for all tool parameters
+- **Error handling**: No credential leaks in error messages
+- **Credentials**: Never hardcoded, never logged, never in git
+
+## Versioning (CalVer)
+
+- Schema: `YYYY.MM.DD.TS` (e.g., `2026.03.13.1`)
+- `package.json`: npm-compatible without leading zeros (`2026.3.13`)
+- Git tags: `v2026.03.13.1` (leading zeros for sorting)
+- CHANGELOG.md: CalVer-based with date headers
+
+## Git Workflow
+
+- **NEVER work on main** — all changes via feature branches + PR
+- **Branching**: `feature/<issue-nr>-<description>`, `fix/<issue-nr>-<description>`, `chore/<description>`
+- **Worktree naming**: `.claude/worktrees/<branch-name>`
+- **GitHub Issues mandatory**: every change must have an associated GH issue
+- **Commit messages**: must reference GH issue — `feat: add DNS override tool (#12)` or `fix: handle SSL timeout (#5)`
+- **No commit without issue reference** (exceptions: initial setup, typo fixes)
+- **PR workflow**: feature branch -> `gh pr create` -> review -> merge into main
+- **After PR merge: branch/worktree cleanup is mandatory** — `git branch -d <branch>`, `git remote prune origin`, remove worktree. Prevents drift.
+
+## Language
+
+- All documentation, code comments, commit messages: **English only**
+
+## Development Setup
+
+```bash
+# Prerequisites: Node.js >= 20, npm
+
+# Install dependencies
+npm install
+
+# Copy and configure environment
+cp .env.example .env
+# Edit .env with your OPNsense API credentials
+
+# Build
+npm run build
+
+# Test
+npm test
+
+# Run (stdio transport)
+node dist/index.js
+```
+
+## Testing
+
+- Unit tests with vitest (mocked API responses)
+- Zod schema validation for invalid inputs
+- Error handling for API errors (401, 403, 404, 500)
+- Run: `npm test`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to mcp-opnsense
+
+Thank you for your interest in contributing!
+
+## Workflow
+
+1. **Issue first** — Create a GitHub issue describing the change before starting work
+2. **Fork & branch** — Fork the repo, create a feature branch: `feature/<issue-nr>-<description>`
+3. **Develop** — Write code, add tests, update documentation
+4. **Test** — Ensure all tests pass: `npm test`
+5. **PR** — Create a pull request referencing the issue
+
+## Branch Naming
+
+- `feature/<issue-nr>-<description>` — New features
+- `fix/<issue-nr>-<description>` — Bug fixes
+- `chore/<description>` — Maintenance tasks
+
+## Commit Messages
+
+Use conventional commits with issue references:
+
+```
+feat: add DNS forward management (#12)
+fix: handle SSL certificate timeout (#5)
+chore: update dependencies
+```
+
+## Code Standards
+
+- TypeScript strict mode
+- All tool parameters validated with Zod schemas
+- No `any` types
+- No SSH or shell execution
+- Credentials only via environment variables
+- Tests for all new tools
+
+## Review
+
+- All PRs require code review before merging
+- Tests must pass
+- Documentation must be updated (especially README.md)
+
+## After Merge
+
+Branch and worktree cleanup is mandatory after PR merge to prevent drift.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,157 @@
+# mcp-opnsense
+
+Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense REST API.
+
+**No SSH. No shell execution. API-only. 3 runtime dependencies.**
+
+## Features
+
+- **DNS/Unbound** — Host overrides, forwards, blocklist, cache management
+- **Firewall** — Rules, aliases, NAT, apply changes
+- **Diagnostics** — ARP table, routes, ping, traceroute, DNS lookup, firewall states/logs
+- **Interfaces** — List, configuration, statistics (read-only)
+- **DHCP** — Leases, static mappings (ISC DHCPv4 + Kea dual support)
+- **System** — Info, backup/restore, service control
+
+## Quick Start
+
+```bash
+# Install
+npm install
+
+# Configure
+cp .env.example .env
+# Edit .env with your OPNsense credentials
+
+# Build
+npm run build
+
+# Run (stdio transport for MCP)
+node dist/index.js
+```
+
+## Claude Code Integration
+
+Add to your Claude Code MCP configuration (`~/.claude/mcp_settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "opnsense": {
+      "command": "node",
+      "args": ["/path/to/mcp-opnsense/dist/index.js"],
+      "env": {
+        "OPNSENSE_URL": "https://10.10.0.1",
+        "OPNSENSE_API_KEY": "your-api-key",
+        "OPNSENSE_API_SECRET": "your-api-secret",
+        "OPNSENSE_VERIFY_SSL": "true"
+      }
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `OPNSENSE_URL` | Yes | — | OPNsense base URL (e.g., `https://10.10.0.1`) |
+| `OPNSENSE_API_KEY` | Yes | — | API key for authentication |
+| `OPNSENSE_API_SECRET` | Yes | — | API secret for authentication |
+| `OPNSENSE_VERIFY_SSL` | No | `true` | Set to `false` for self-signed certificates |
+| `OPNSENSE_TIMEOUT` | No | `30000` | Request timeout in milliseconds |
+
+## Available Tools
+
+### DNS/Unbound (12 tools)
+| Tool | Description |
+|------|-------------|
+| `opnsense_dns_list_overrides` | List host overrides (A/AAAA/CNAME) |
+| `opnsense_dns_add_override` | Add a host override record |
+| `opnsense_dns_delete_override` | Delete a host override by UUID |
+| `opnsense_dns_list_forwards` | List DNS forward servers |
+| `opnsense_dns_add_forward` | Add a DNS forward server |
+| `opnsense_dns_delete_forward` | Delete a DNS forward by UUID |
+| `opnsense_dns_list_blocklist` | List blocked domains |
+| `opnsense_dns_block_domain` | Block a domain |
+| `opnsense_dns_unblock_domain` | Unblock a domain by UUID |
+| `opnsense_dns_flush_cache` | Flush DNS cache |
+| `opnsense_dns_diagnostics` | Get DNS cache and statistics |
+| `opnsense_dns_apply` | Apply DNS changes (reconfigure Unbound) |
+
+### Firewall (8 tools)
+| Tool | Description |
+|------|-------------|
+| `opnsense_fw_list_rules` | List firewall filter rules |
+| `opnsense_fw_add_rule` | Create a firewall rule |
+| `opnsense_fw_update_rule` | Update a firewall rule by UUID |
+| `opnsense_fw_delete_rule` | Delete a firewall rule by UUID |
+| `opnsense_fw_toggle_rule` | Enable/disable a firewall rule |
+| `opnsense_fw_list_aliases` | List firewall aliases |
+| `opnsense_fw_manage_alias` | Create/update/delete aliases |
+| `opnsense_fw_apply` | Apply firewall changes |
+
+### Diagnostics (8 tools)
+| Tool | Description |
+|------|-------------|
+| `opnsense_diag_arp_table` | Get ARP table |
+| `opnsense_diag_routes` | Get routing table |
+| `opnsense_diag_ping` | Ping a host |
+| `opnsense_diag_traceroute` | Traceroute to a host |
+| `opnsense_diag_dns_lookup` | Perform DNS lookup |
+| `opnsense_diag_fw_states` | List active firewall states |
+| `opnsense_diag_fw_logs` | Get firewall logs |
+| `opnsense_diag_system_info` | Get system info (version, uptime) |
+
+### Interfaces (3 tools, read-only)
+| Tool | Description |
+|------|-------------|
+| `opnsense_if_list` | List all interfaces |
+| `opnsense_if_get` | Get interface configuration |
+| `opnsense_if_stats` | Get interface statistics |
+
+### DHCP (5 tools, ISC + Kea)
+| Tool | Description |
+|------|-------------|
+| `opnsense_dhcp_list_leases` | List active DHCP leases |
+| `opnsense_dhcp_find_lease` | Find lease by IP, MAC, or hostname |
+| `opnsense_dhcp_list_static` | List static DHCP mappings |
+| `opnsense_dhcp_add_static` | Add a static DHCP mapping |
+| `opnsense_dhcp_delete_static` | Delete a static mapping by UUID |
+
+### System (5 tools)
+| Tool | Description |
+|------|-------------|
+| `opnsense_sys_info` | Get system version and uptime |
+| `opnsense_sys_backup` | Create configuration backup |
+| `opnsense_sys_restore` | Restore configuration (requires confirmation) |
+| `opnsense_svc_list` | List services and their status |
+| `opnsense_svc_control` | Start/stop/restart a service |
+
+## Security
+
+- **Transport**: stdio only — no HTTP endpoints exposed
+- **Authentication**: OPNsense API key/secret via environment variables
+- **SSL**: Enabled by default
+- **No SSH**: All operations use the OPNsense REST API exclusively
+- **Input validation**: Strict Zod schemas for all tool parameters
+- See [SECURITY.md](SECURITY.md) for the full security policy
+
+## Development
+
+```bash
+# Run tests
+npm test
+
+# Build
+npm run build
+
+# Type check
+npx tsc --noEmit
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+
+## License
+
+MIT — see [LICENSE](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Design Principles
+
+- **API-only**: All operations use the OPNsense REST API. No SSH, no shell execution.
+- **Transport**: stdio only — no HTTP endpoints are exposed by this server.
+- **Credentials**: API key/secret exclusively via environment variables. Never hardcoded, logged, or committed.
+- **SSL**: Verification enabled by default. Can be disabled for self-signed certificates via `OPNSENSE_VERIFY_SSL=false`.
+- **Input validation**: All tool parameters are validated with strict Zod schemas.
+- **Error handling**: Error messages never leak credentials or sensitive configuration.
+- **Destructive operations**: `opnsense_sys_restore` requires an explicit confirmation parameter.
+
+## Reporting Vulnerabilities
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Do NOT** create a public GitHub issue
+2. Email: security@itunified.io
+3. Include: description, steps to reproduce, potential impact
+
+We will respond within 48 hours and work with you on a fix before public disclosure.
+
+## Supported Versions
+
+Only the latest CalVer release is actively supported with security patches.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2692 @@
+{
+  "name": "@itunified/mcp-opnsense",
+  "version": "2026.3.13",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@itunified/mcp-opnsense",
+      "version": "2026.3.13",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.0",
+        "axios": "^1.7.0",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.5.0",
+        "vitest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@itunified/mcp-opnsense",
+  "version": "2026.3.13",
+  "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "mcp",
+    "opnsense",
+    "firewall",
+    "dns",
+    "model-context-protocol"
+  ],
+  "author": "itunified.io",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/itunified-io/mcp-opnsense.git"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.24.0",
+    "axios": "^1.7.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/src/client/opnsense-client.ts
+++ b/src/client/opnsense-client.ts
@@ -1,0 +1,70 @@
+import axios, { type AxiosInstance } from "axios";
+import https from "node:https";
+import type { OPNsenseConfig } from "./types.js";
+import { extractError } from "../utils/errors.js";
+
+export class OPNsenseClient {
+  private readonly http: AxiosInstance;
+
+  constructor(private readonly config: OPNsenseConfig) {
+    const baseURL = config.url.replace(/\/+$/, "") + "/api";
+
+    this.http = axios.create({
+      baseURL,
+      timeout: config.timeout ?? 30000,
+      auth: {
+        username: config.apiKey,
+        password: config.apiSecret,
+      },
+      httpsAgent: new https.Agent({
+        rejectUnauthorized: config.verifySsl ?? true,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+    });
+  }
+
+  async get<T>(path: string): Promise<T> {
+    try {
+      const response = await this.http.get<T>(path);
+      return response.data;
+    } catch (error: unknown) {
+      throw extractError(error, `GET ${path}`);
+    }
+  }
+
+  async post<T>(path: string, data?: unknown): Promise<T> {
+    try {
+      const response = await this.http.post<T>(path, data ?? {});
+      return response.data;
+    } catch (error: unknown) {
+      throw extractError(error, `POST ${path}`);
+    }
+  }
+
+  async delete<T>(path: string): Promise<T> {
+    try {
+      const response = await this.http.delete<T>(path);
+      return response.data;
+    } catch (error: unknown) {
+      throw extractError(error, `DELETE ${path}`);
+    }
+  }
+
+  static fromEnv(): OPNsenseClient {
+    const url = process.env["OPNSENSE_URL"];
+    const apiKey = process.env["OPNSENSE_API_KEY"];
+    const apiSecret = process.env["OPNSENSE_API_SECRET"];
+
+    if (!url) throw new Error("OPNSENSE_URL environment variable is required");
+    if (!apiKey) throw new Error("OPNSENSE_API_KEY environment variable is required");
+    if (!apiSecret) throw new Error("OPNSENSE_API_SECRET environment variable is required");
+
+    const verifySsl = process.env["OPNSENSE_VERIFY_SSL"] !== "false";
+    const timeout = parseInt(process.env["OPNSENSE_TIMEOUT"] ?? "30000", 10);
+
+    return new OPNsenseClient({ url, apiKey, apiSecret, verifySsl, timeout });
+  }
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,0 +1,171 @@
+export interface OPNsenseConfig {
+  url: string;
+  apiKey: string;
+  apiSecret: string;
+  verifySsl?: boolean;
+  timeout?: number;
+}
+
+export interface ApiResponse<T> {
+  status: string;
+  data: T;
+}
+
+export interface SearchResult<T> {
+  rows: T[];
+  rowCount: number;
+  total: number;
+  current: number;
+}
+
+export interface UuidResponse {
+  uuid: string;
+}
+
+export interface StatusResponse {
+  status: string;
+  result: string;
+}
+
+// DNS
+
+export interface HostOverride {
+  uuid?: string;
+  enabled: string;
+  hostname: string;
+  domain: string;
+  server: string;
+  description: string;
+}
+
+export interface DomainOverride {
+  uuid?: string;
+  enabled: string;
+  domain: string;
+  server: string;
+  description: string;
+}
+
+export interface ForwardServer {
+  uuid?: string;
+  enabled: string;
+  server: string;
+  port: string;
+  domain: string;
+  description: string;
+}
+
+// Firewall
+
+export interface FilterRule {
+  uuid?: string;
+  enabled: string;
+  action: string;
+  direction: string;
+  interface: string;
+  protocol: string;
+  source_net: string;
+  source_port: string;
+  destination_net: string;
+  destination_port: string;
+  description: string;
+  log: string;
+  sequence: string;
+}
+
+export interface Alias {
+  uuid?: string;
+  enabled: string;
+  name: string;
+  type: string;
+  content: string;
+  description: string;
+}
+
+// Interfaces
+
+export interface InterfaceInfo {
+  device: string;
+  description: string;
+  status: string;
+  ipv4: string[];
+  ipv6: string[];
+  media: string;
+  macaddr: string;
+  mtu: string;
+}
+
+export interface InterfaceStats {
+  device: string;
+  bytesIn: number;
+  bytesOut: number;
+  packetsIn: number;
+  packetsOut: number;
+  errorsIn: number;
+  errorsOut: number;
+  collisions: number;
+}
+
+// DHCP
+
+export interface DhcpLease {
+  address: string;
+  hwaddr: string;
+  hostname: string;
+  starts: string;
+  ends: string;
+  status: string;
+  interface: string;
+}
+
+export interface StaticMapping {
+  uuid?: string;
+  mac: string;
+  ipaddr: string;
+  hostname: string;
+  description: string;
+  interface: string;
+}
+
+// System
+
+export interface SystemInfo {
+  name: string;
+  versions: Record<string, string>;
+  cpu: string;
+  memory: string;
+  uptime: string;
+  disk: string;
+}
+
+export interface ServiceInfo {
+  id: string;
+  name: string;
+  description: string;
+  running: boolean;
+}
+
+export interface BackupInfo {
+  time: string;
+  description: string;
+  size: number;
+  filename: string;
+}
+
+// Diagnostics
+
+export interface ArpEntry {
+  ip: string;
+  mac: string;
+  intf: string;
+  hostname: string;
+  manufacturer: string;
+}
+
+export interface RouteEntry {
+  destination: string;
+  gateway: string;
+  flags: string;
+  interface: string;
+  expire: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,69 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { OPNsenseClient } from './client/opnsense-client.js';
+import { dnsToolDefinitions, handleDnsTool } from './tools/dns.js';
+import { firewallToolDefinitions, handleFirewallTool } from './tools/firewall.js';
+import { diagnosticsToolDefinitions, handleDiagnosticsTool } from './tools/diagnostics.js';
+import { interfacesToolDefinitions, handleInterfacesTool } from './tools/interfaces.js';
+import { dhcpToolDefinitions, handleDhcpTool } from './tools/dhcp.js';
+import { systemToolDefinitions, handleSystemTool } from './tools/system.js';
+
+const allToolDefinitions = [
+  ...dnsToolDefinitions,
+  ...firewallToolDefinitions,
+  ...diagnosticsToolDefinitions,
+  ...interfacesToolDefinitions,
+  ...dhcpToolDefinitions,
+  ...systemToolDefinitions,
+];
+
+const toolHandlers = new Map<
+  string,
+  (name: string, args: Record<string, unknown>, client: OPNsenseClient) => Promise<{ content: Array<{ type: 'text'; text: string }> }>
+>();
+
+for (const def of dnsToolDefinitions) toolHandlers.set(def.name, handleDnsTool);
+for (const def of firewallToolDefinitions) toolHandlers.set(def.name, handleFirewallTool);
+for (const def of diagnosticsToolDefinitions) toolHandlers.set(def.name, handleDiagnosticsTool);
+for (const def of interfacesToolDefinitions) toolHandlers.set(def.name, handleInterfacesTool);
+for (const def of dhcpToolDefinitions) toolHandlers.set(def.name, handleDhcpTool);
+for (const def of systemToolDefinitions) toolHandlers.set(def.name, handleSystemTool);
+
+const server = new Server(
+  { name: 'mcp-opnsense', version: '2026.3.13' },
+  { capabilities: { tools: {} } }
+);
+
+const client = OPNsenseClient.fromEnv();
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: allToolDefinitions,
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  const handler = toolHandlers.get(name);
+
+  if (!handler) {
+    return {
+      content: [{ type: 'text' as const, text: `Unknown tool: ${name}` }],
+      isError: true,
+    };
+  }
+
+  return handler(name, (args ?? {}) as Record<string, unknown>, client);
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((error) => {
+  console.error('Server failed to start:', error);
+  process.exit(1);
+});

--- a/src/tools/dhcp.ts
+++ b/src/tools/dhcp.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+import type { OPNsenseClient } from "../client/opnsense-client.js";
+import { UuidSchema, MacAddressSchema } from "../utils/validation.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const FindLeaseSchema = z.object({
+  query: z.string().min(1, "Search query is required (IP, MAC, or hostname)"),
+});
+
+const AddStaticMapSchema = z.object({
+  mac: MacAddressSchema,
+  ipaddr: z.string().ip({ message: "Invalid IP address" }),
+  hostname: z.string().optional(),
+  description: z.string().optional(),
+});
+
+const DeleteStaticMapSchema = z.object({
+  uuid: UuidSchema,
+});
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const dhcpToolDefinitions = [
+  {
+    name: "opnsense_dhcp_list_leases",
+    description: "List all current DHCPv4 leases",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_dhcp_find_lease",
+    description: "Search DHCPv4 leases by IP address, MAC address, or hostname",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        query: {
+          type: "string",
+          description: "Search term — IP address, MAC address, or hostname",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "opnsense_dhcp_list_static",
+    description: "List all static DHCP mappings (MAC-to-IP reservations)",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_dhcp_add_static",
+    description:
+      "Add a static DHCP mapping (MAC-to-IP reservation). Requires DHCP service restart to take effect.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        mac: {
+          type: "string",
+          description: "MAC address (format: AA:BB:CC:DD:EE:FF)",
+        },
+        ipaddr: {
+          type: "string",
+          description: "IP address to assign",
+        },
+        hostname: {
+          type: "string",
+          description: "Optional hostname for the mapping",
+        },
+        description: {
+          type: "string",
+          description: "Optional description",
+        },
+      },
+      required: ["mac", "ipaddr"],
+    },
+  },
+  {
+    name: "opnsense_dhcp_delete_static",
+    description: "Delete a static DHCP mapping by UUID",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the static mapping to delete" },
+      },
+      required: ["uuid"],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleDhcpTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: OPNsenseClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "opnsense_dhcp_list_leases": {
+        const result = await client.get("/dhcpv4/leases/searchLease");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dhcp_find_lease": {
+        const parsed = FindLeaseSchema.parse(args);
+        const result = await client.get(
+          `/dhcpv4/leases/searchLease?searchPhrase=${encodeURIComponent(parsed.query)}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dhcp_list_static": {
+        const result = await client.get("/dhcpv4/leases/searchStaticMap");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dhcp_add_static": {
+        const parsed = AddStaticMapSchema.parse(args);
+        const result = await client.post("/dhcpv4/leases/addStaticMap", {
+          staticmap: {
+            mac: parsed.mac,
+            ipaddr: parsed.ipaddr,
+            hostname: parsed.hostname ?? "",
+            description: parsed.description ?? "",
+          },
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dhcp_delete_static": {
+        const { uuid } = DeleteStaticMapSchema.parse(args);
+        const result = await client.post(`/dhcpv4/leases/delStaticMap/${uuid}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown DHCP tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -1,0 +1,214 @@
+import { z } from "zod";
+import type { OPNsenseClient } from "../client/opnsense-client.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const ArpFilterSchema = z.object({
+  ip: z.string().optional(),
+  mac: z.string().optional(),
+  interface: z.string().optional(),
+});
+
+const PingSchema = z.object({
+  address: z.string().min(1, "Address is required"),
+  count: z.number().int().min(1).max(100).optional().default(3),
+});
+
+const TracerouteSchema = z.object({
+  address: z.string().min(1, "Address is required"),
+});
+
+const DnsLookupSchema = z.object({
+  hostname: z.string().min(1, "Hostname is required"),
+});
+
+const FwLogsSchema = z.object({
+  limit: z.number().int().min(1).max(5000).optional().default(50),
+});
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const diagnosticsToolDefinitions = [
+  {
+    name: "opnsense_diag_arp_table",
+    description:
+      "Show the ARP table (IP-to-MAC mappings). Optionally filter by IP, MAC, or interface.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        ip: { type: "string", description: "Filter by IP address" },
+        mac: { type: "string", description: "Filter by MAC address" },
+        interface: { type: "string", description: "Filter by interface name" },
+      },
+    },
+  },
+  {
+    name: "opnsense_diag_routes",
+    description: "Show the routing table",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_diag_ping",
+    description: "Ping a host from the OPNsense firewall",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        address: {
+          type: "string",
+          description: "IP address or hostname to ping",
+        },
+        count: {
+          type: "number",
+          description: "Number of ping packets (default: 3, max: 100)",
+        },
+      },
+      required: ["address"],
+    },
+  },
+  {
+    name: "opnsense_diag_traceroute",
+    description: "Run a traceroute from the OPNsense firewall to a destination",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        address: {
+          type: "string",
+          description: "IP address or hostname to traceroute",
+        },
+      },
+      required: ["address"],
+    },
+  },
+  {
+    name: "opnsense_diag_dns_lookup",
+    description: "Perform a DNS lookup from the OPNsense firewall",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        hostname: {
+          type: "string",
+          description: "Hostname to look up",
+        },
+      },
+      required: ["hostname"],
+    },
+  },
+  {
+    name: "opnsense_diag_fw_states",
+    description: "List active firewall connection tracking states",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_diag_fw_logs",
+    description: "Retrieve recent firewall log entries",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        limit: {
+          type: "number",
+          description: "Number of log entries to retrieve (default: 50, max: 5000)",
+        },
+      },
+    },
+  },
+  {
+    name: "opnsense_diag_system_info",
+    description: "Get system status information (CPU, memory, uptime, disk, versions)",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleDiagnosticsTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: OPNsenseClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "opnsense_diag_arp_table": {
+        const filters = ArpFilterSchema.parse(args);
+        const result = await client.get<unknown>("/diagnostics/interface/getArp");
+
+        // Apply client-side filtering if any filter params provided
+        if (filters.ip || filters.mac || filters.interface) {
+          const entries = Array.isArray(result) ? result : [];
+          const filtered = entries.filter((entry: Record<string, unknown>) => {
+            if (filters.ip && !String(entry["ip"] ?? "").includes(filters.ip)) return false;
+            if (filters.mac && !String(entry["mac"] ?? "").toLowerCase().includes(filters.mac.toLowerCase())) return false;
+            if (filters.interface && String(entry["intf"] ?? "") !== filters.interface) return false;
+            return true;
+          });
+          return { content: [{ type: "text", text: JSON.stringify(filtered, null, 2) }] };
+        }
+
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_diag_routes": {
+        const result = await client.get("/diagnostics/interface/getRoutes");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_diag_ping": {
+        const parsed = PingSchema.parse(args);
+        const result = await client.post("/diagnostics/interface/ping", {
+          address: parsed.address,
+          count: String(parsed.count),
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_diag_traceroute": {
+        const parsed = TracerouteSchema.parse(args);
+        const result = await client.post("/diagnostics/interface/traceroute", {
+          address: parsed.address,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_diag_dns_lookup": {
+        const parsed = DnsLookupSchema.parse(args);
+        const result = await client.post("/diagnostics/dns/lookup", {
+          hostname: parsed.hostname,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_diag_fw_states": {
+        const result = await client.get("/diagnostics/firewall/listStates");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_diag_fw_logs": {
+        const parsed = FwLogsSchema.parse(args);
+        const result = await client.get(
+          `/diagnostics/firewall/log?limit=${parsed.limit}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_diag_system_info": {
+        const result = await client.get("/core/system/status");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown diagnostics tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/src/tools/dns.ts
+++ b/src/tools/dns.ts
@@ -1,0 +1,283 @@
+import { z } from "zod";
+import type { OPNsenseClient } from "../client/opnsense-client.js";
+import { UuidSchema, HostnameSchema, DomainSchema } from "../utils/validation.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const AddOverrideSchema = z.object({
+  hostname: HostnameSchema,
+  domain: DomainSchema,
+  server: z.string().ip({ message: "Invalid IP address" }),
+  description: z.string().optional(),
+  type: z.enum(["A", "AAAA", "CNAME"]).optional().default("A"),
+});
+
+const DeleteOverrideSchema = z.object({
+  uuid: UuidSchema,
+});
+
+const AddForwardSchema = z.object({
+  domain: DomainSchema,
+  server: z.string().ip({ message: "Invalid server IP address" }),
+  port: z.number().int().min(1).max(65535).optional().default(53),
+});
+
+const DeleteForwardSchema = z.object({
+  uuid: UuidSchema,
+});
+
+const BlockDomainSchema = z.object({
+  domain: DomainSchema,
+  server: z.string().optional().default(""),
+  description: z.string().optional(),
+});
+
+const UnblockDomainSchema = z.object({
+  uuid: UuidSchema,
+});
+
+const DnsLookupSchema = z.object({
+  hostname: z.string().min(1, "Hostname is required"),
+});
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const dnsToolDefinitions = [
+  {
+    name: "opnsense_dns_list_overrides",
+    description: "List all DNS host overrides (A/AAAA/CNAME records) configured in Unbound",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_dns_add_override",
+    description:
+      "Add a DNS host override (A/AAAA/CNAME record) to Unbound. Run opnsense_dns_apply afterwards to activate.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        hostname: { type: "string", description: "Hostname (e.g. 'myserver')" },
+        domain: { type: "string", description: "Domain (e.g. 'home.lab')" },
+        server: { type: "string", description: "Target IP address" },
+        description: { type: "string", description: "Optional description" },
+        type: {
+          type: "string",
+          enum: ["A", "AAAA", "CNAME"],
+          description: "Record type (default: A)",
+        },
+      },
+      required: ["hostname", "domain", "server"],
+    },
+  },
+  {
+    name: "opnsense_dns_delete_override",
+    description:
+      "Delete a DNS host override by UUID. Run opnsense_dns_apply afterwards to activate.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the host override to delete" },
+      },
+      required: ["uuid"],
+    },
+  },
+  {
+    name: "opnsense_dns_list_forwards",
+    description: "List all DNS-over-TLS forwarding servers configured in Unbound",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_dns_add_forward",
+    description:
+      "Add a DNS forwarding server (DNS-over-TLS). Run opnsense_dns_apply afterwards to activate.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        domain: { type: "string", description: "Domain to forward (e.g. 'example.com')" },
+        server: { type: "string", description: "DNS server IP address" },
+        port: {
+          type: "number",
+          description: "DNS server port (default: 53)",
+        },
+      },
+      required: ["domain", "server"],
+    },
+  },
+  {
+    name: "opnsense_dns_delete_forward",
+    description:
+      "Delete a DNS forwarding entry by UUID. Run opnsense_dns_apply afterwards to activate.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the forwarding entry to delete" },
+      },
+      required: ["uuid"],
+    },
+  },
+  {
+    name: "opnsense_dns_list_blocklist",
+    description: "List all domain overrides (used for domain blocking) in Unbound",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_dns_block_domain",
+    description:
+      "Block a domain by adding a domain override with an empty server. Run opnsense_dns_apply afterwards to activate.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        domain: { type: "string", description: "Domain to block (e.g. 'ads.example.com')" },
+        server: {
+          type: "string",
+          description: "Server to redirect to (empty string = block, default: empty)",
+        },
+        description: { type: "string", description: "Optional description" },
+      },
+      required: ["domain"],
+    },
+  },
+  {
+    name: "opnsense_dns_unblock_domain",
+    description:
+      "Unblock a domain by deleting its domain override. Run opnsense_dns_apply afterwards to activate.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the domain override to delete" },
+      },
+      required: ["uuid"],
+    },
+  },
+  {
+    name: "opnsense_dns_flush_cache",
+    description: "Flush the Unbound DNS cache and DNSBL data",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_dns_diagnostics",
+    description: "Dump the current Unbound DNS cache for diagnostic purposes",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_dns_apply",
+    description: "Apply pending DNS/Unbound configuration changes (reconfigure service)",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleDnsTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: OPNsenseClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "opnsense_dns_list_overrides": {
+        const result = await client.get("/unbound/settings/searchHostOverride");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_add_override": {
+        const parsed = AddOverrideSchema.parse(args);
+        const result = await client.post("/unbound/settings/addHostOverride", {
+          host: {
+            enabled: "1",
+            hostname: parsed.hostname,
+            domain: parsed.domain,
+            rr: parsed.type,
+            server: parsed.server,
+            description: parsed.description ?? "",
+          },
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_delete_override": {
+        const { uuid } = DeleteOverrideSchema.parse(args);
+        const result = await client.post(`/unbound/settings/delHostOverride/${uuid}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_list_forwards": {
+        const result = await client.get("/unbound/settings/searchDot");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_add_forward": {
+        const parsed = AddForwardSchema.parse(args);
+        const result = await client.post("/unbound/settings/addDot", {
+          dot: {
+            enabled: "1",
+            domain: parsed.domain,
+            server: parsed.server,
+            port: String(parsed.port),
+          },
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_delete_forward": {
+        const { uuid } = DeleteForwardSchema.parse(args);
+        const result = await client.post(`/unbound/settings/delDot/${uuid}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_list_blocklist": {
+        const result = await client.get("/unbound/settings/searchDomainOverride");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_block_domain": {
+        const parsed = BlockDomainSchema.parse(args);
+        const result = await client.post("/unbound/settings/addDomainOverride", {
+          domain: {
+            enabled: "1",
+            domain: parsed.domain,
+            server: parsed.server,
+            description: parsed.description ?? "",
+          },
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_unblock_domain": {
+        const { uuid } = UnblockDomainSchema.parse(args);
+        const result = await client.post(`/unbound/settings/delDomainOverride/${uuid}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_flush_cache": {
+        const result = await client.post("/unbound/service/dnsbl");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_diagnostics": {
+        const result = await client.get("/unbound/diagnostics/dumpcache");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_apply": {
+        const result = await client.post("/unbound/service/reconfigure");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown DNS tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/src/tools/firewall.ts
+++ b/src/tools/firewall.ts
@@ -1,0 +1,344 @@
+import { z } from "zod";
+import type { OPNsenseClient } from "../client/opnsense-client.js";
+import {
+  UuidSchema,
+  FirewallActionSchema,
+  DirectionSchema,
+  ProtocolSchema,
+} from "../utils/validation.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const AddRuleSchema = z.object({
+  action: FirewallActionSchema,
+  direction: DirectionSchema,
+  interface: z.string().optional(),
+  protocol: ProtocolSchema.optional(),
+  source_net: z.string().optional(),
+  destination_net: z.string().optional(),
+  destination_port: z.string().optional(),
+  description: z.string().optional(),
+});
+
+const UpdateRuleSchema = AddRuleSchema.extend({
+  uuid: UuidSchema,
+});
+
+const DeleteRuleSchema = z.object({
+  uuid: UuidSchema,
+});
+
+const ToggleRuleSchema = z.object({
+  uuid: UuidSchema,
+  enabled: z.enum(["0", "1"]),
+});
+
+const ManageAliasSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("create"),
+    name: z.string().min(1, "Alias name is required"),
+    type: z.string().min(1, "Alias type is required"),
+    content: z.string().min(1, "Alias content is required"),
+    description: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal("update"),
+    uuid: UuidSchema,
+    name: z.string().optional(),
+    type: z.string().optional(),
+    content: z.string().optional(),
+    description: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal("delete"),
+    uuid: UuidSchema,
+  }),
+]);
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const firewallToolDefinitions = [
+  {
+    name: "opnsense_fw_list_rules",
+    description: "List all firewall filter rules",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_fw_add_rule",
+    description:
+      "Add a new firewall filter rule. Run opnsense_fw_apply afterwards to activate.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string",
+          enum: ["pass", "block", "reject"],
+          description: "Rule action",
+        },
+        direction: {
+          type: "string",
+          enum: ["in", "out"],
+          description: "Traffic direction",
+        },
+        interface: { type: "string", description: "Interface name (e.g. 'lan', 'wan')" },
+        protocol: {
+          type: "string",
+          enum: ["TCP", "UDP", "ICMP", "any"],
+          description: "Protocol",
+        },
+        source_net: {
+          type: "string",
+          description: "Source network (CIDR, alias, or 'any')",
+        },
+        destination_net: {
+          type: "string",
+          description: "Destination network (CIDR, alias, or 'any')",
+        },
+        destination_port: {
+          type: "string",
+          description: "Destination port or range (e.g. '443', '80-443')",
+        },
+        description: { type: "string", description: "Rule description" },
+      },
+      required: ["action", "direction"],
+    },
+  },
+  {
+    name: "opnsense_fw_update_rule",
+    description:
+      "Update an existing firewall filter rule by UUID. Run opnsense_fw_apply afterwards to activate.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the rule to update" },
+        action: {
+          type: "string",
+          enum: ["pass", "block", "reject"],
+          description: "Rule action",
+        },
+        direction: {
+          type: "string",
+          enum: ["in", "out"],
+          description: "Traffic direction",
+        },
+        interface: { type: "string", description: "Interface name" },
+        protocol: {
+          type: "string",
+          enum: ["TCP", "UDP", "ICMP", "any"],
+          description: "Protocol",
+        },
+        source_net: { type: "string", description: "Source network" },
+        destination_net: { type: "string", description: "Destination network" },
+        destination_port: { type: "string", description: "Destination port or range" },
+        description: { type: "string", description: "Rule description" },
+      },
+      required: ["uuid", "action", "direction"],
+    },
+  },
+  {
+    name: "opnsense_fw_delete_rule",
+    description:
+      "Delete a firewall filter rule by UUID. Run opnsense_fw_apply afterwards to activate.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the rule to delete" },
+      },
+      required: ["uuid"],
+    },
+  },
+  {
+    name: "opnsense_fw_toggle_rule",
+    description:
+      "Enable or disable a firewall rule by UUID. Run opnsense_fw_apply afterwards to activate.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the rule to toggle" },
+        enabled: {
+          type: "string",
+          enum: ["0", "1"],
+          description: "1 to enable, 0 to disable",
+        },
+      },
+      required: ["uuid", "enabled"],
+    },
+  },
+  {
+    name: "opnsense_fw_list_aliases",
+    description: "List all firewall aliases (host groups, networks, ports, URLs)",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_fw_manage_alias",
+    description:
+      "Create, update, or delete a firewall alias. Run opnsense_fw_apply afterwards to activate.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string",
+          enum: ["create", "update", "delete"],
+          description: "Action to perform",
+        },
+        uuid: {
+          type: "string",
+          description: "UUID of alias (required for update/delete)",
+        },
+        name: {
+          type: "string",
+          description: "Alias name (required for create)",
+        },
+        type: {
+          type: "string",
+          description: "Alias type: host, network, port, url, etc. (required for create)",
+        },
+        content: {
+          type: "string",
+          description: "Alias content — newline-separated values (required for create)",
+        },
+        description: { type: "string", description: "Alias description" },
+      },
+      required: ["action"],
+    },
+  },
+  {
+    name: "opnsense_fw_apply",
+    description: "Apply pending firewall configuration changes",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleFirewallTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: OPNsenseClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "opnsense_fw_list_rules": {
+        const result = await client.get("/firewall/filter/searchRule");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_fw_add_rule": {
+        const parsed = AddRuleSchema.parse(args);
+        const result = await client.post("/firewall/filter/addRule", {
+          rule: {
+            enabled: "1",
+            action: parsed.action,
+            direction: parsed.direction,
+            interface: parsed.interface ?? "",
+            ipprotocol: "inet",
+            protocol: parsed.protocol ?? "any",
+            source_net: parsed.source_net ?? "any",
+            destination_net: parsed.destination_net ?? "any",
+            destination_port: parsed.destination_port ?? "",
+            description: parsed.description ?? "",
+          },
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_fw_update_rule": {
+        const parsed = UpdateRuleSchema.parse(args);
+        const result = await client.post(`/firewall/filter/setRule/${parsed.uuid}`, {
+          rule: {
+            enabled: "1",
+            action: parsed.action,
+            direction: parsed.direction,
+            interface: parsed.interface ?? "",
+            ipprotocol: "inet",
+            protocol: parsed.protocol ?? "any",
+            source_net: parsed.source_net ?? "any",
+            destination_net: parsed.destination_net ?? "any",
+            destination_port: parsed.destination_port ?? "",
+            description: parsed.description ?? "",
+          },
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_fw_delete_rule": {
+        const { uuid } = DeleteRuleSchema.parse(args);
+        const result = await client.post(`/firewall/filter/delRule/${uuid}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_fw_toggle_rule": {
+        const parsed = ToggleRuleSchema.parse(args);
+        const result = await client.post(
+          `/firewall/filter/toggleRule/${parsed.uuid}/${parsed.enabled}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_fw_list_aliases": {
+        const result = await client.get("/firewall/alias/searchItem");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_fw_manage_alias": {
+        const parsed = ManageAliasSchema.parse(args);
+
+        switch (parsed.action) {
+          case "create": {
+            const result = await client.post("/firewall/alias/addItem", {
+              alias: {
+                enabled: "1",
+                name: parsed.name,
+                type: parsed.type,
+                content: parsed.content,
+                description: parsed.description ?? "",
+              },
+            });
+            return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+          }
+          case "update": {
+            const payload: Record<string, string> = {};
+            if (parsed.name !== undefined) payload["name"] = parsed.name;
+            if (parsed.type !== undefined) payload["type"] = parsed.type;
+            if (parsed.content !== undefined) payload["content"] = parsed.content;
+            if (parsed.description !== undefined) payload["description"] = parsed.description;
+
+            const result = await client.post(`/firewall/alias/setItem/${parsed.uuid}`, {
+              alias: payload,
+            });
+            return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+          }
+          case "delete": {
+            const result = await client.post(`/firewall/alias/delItem/${parsed.uuid}`);
+            return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+          }
+        }
+        break;
+      }
+
+      case "opnsense_fw_apply": {
+        const result = await client.post("/firewall/filter/apply");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown firewall tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+
+  // Unreachable but satisfies TypeScript control-flow analysis
+  return { content: [{ type: "text", text: `Unhandled firewall tool: ${name}` }] };
+}

--- a/src/tools/interfaces.ts
+++ b/src/tools/interfaces.ts
@@ -1,0 +1,100 @@
+import { z } from "zod";
+import type { OPNsenseClient } from "../client/opnsense-client.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const GetInterfaceSchema = z.object({
+  interface_name: z.string().min(1, "Interface name is required"),
+});
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const interfacesToolDefinitions = [
+  {
+    name: "opnsense_if_list",
+    description: "List all network interface names and their device mappings",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_if_get",
+    description:
+      "Get detailed configuration for a specific network interface (IP addresses, status, MTU, etc.)",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        interface_name: {
+          type: "string",
+          description: "Interface name (e.g. 'lan', 'wan', 'opt1')",
+        },
+      },
+      required: ["interface_name"],
+    },
+  },
+  {
+    name: "opnsense_if_stats",
+    description:
+      "Get traffic statistics for all interfaces (bytes, packets, errors, collisions)",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleInterfacesTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: OPNsenseClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "opnsense_if_list": {
+        const result = await client.get("/diagnostics/interface/getInterfaceNames");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_if_get": {
+        const parsed = GetInterfaceSchema.parse(args);
+        const allInterfaces = await client.get<Record<string, unknown>>(
+          "/diagnostics/interface/getInterfaceConfig",
+        );
+
+        // The API returns all interfaces; filter to the requested one
+        const interfaceData = allInterfaces[parsed.interface_name];
+        if (!interfaceData) {
+          const available = Object.keys(allInterfaces).join(", ");
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Interface '${parsed.interface_name}' not found. Available interfaces: ${available}`,
+              },
+            ],
+          };
+        }
+
+        return { content: [{ type: "text", text: JSON.stringify(interfaceData, null, 2) }] };
+      }
+
+      case "opnsense_if_stats": {
+        const result = await client.get("/diagnostics/interface/getInterfaceStatistics");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown interfaces tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+import type { OPNsenseClient } from "../client/opnsense-client.js";
+import { ServiceActionSchema } from "../utils/validation.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const RestoreSchema = z.object({
+  backup_data: z.string().min(1, "Backup data is required"),
+  confirm: z.literal(true, {
+    errorMap: () => ({ message: "confirm must be true to proceed with restore" }),
+  }),
+});
+
+const ServiceControlSchema = z.object({
+  service_name: z.string().min(1, "Service name is required"),
+  action: ServiceActionSchema,
+});
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const systemToolDefinitions = [
+  {
+    name: "opnsense_sys_info",
+    description:
+      "Get system status information (hostname, versions, CPU, memory, uptime, disk usage)",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_sys_backup",
+    description: "Create a configuration backup of the OPNsense system",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_sys_restore",
+    description:
+      "Restore a configuration backup. DESTRUCTIVE: replaces the current configuration. Requires explicit confirmation.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        backup_data: {
+          type: "string",
+          description: "The backup XML data to restore",
+        },
+        confirm: {
+          type: "boolean",
+          description: "Must be true to confirm the restore operation",
+          enum: [true],
+        },
+      },
+      required: ["backup_data", "confirm"],
+    },
+  },
+  {
+    name: "opnsense_svc_list",
+    description: "List all services and their running status",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_svc_control",
+    description: "Start, stop, or restart a service by name",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        service_name: {
+          type: "string",
+          description: "Name of the service (e.g. 'unbound', 'openssh', 'configd')",
+        },
+        action: {
+          type: "string",
+          enum: ["start", "stop", "restart"],
+          description: "Action to perform on the service",
+        },
+      },
+      required: ["service_name", "action"],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleSystemTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: OPNsenseClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "opnsense_sys_info": {
+        const result = await client.get("/core/system/status");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_sys_backup": {
+        const result = await client.post("/core/backup/backup");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_sys_restore": {
+        const parsed = RestoreSchema.parse(args);
+        const result = await client.post("/core/backup/restore", {
+          backupdata: parsed.backup_data,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_svc_list": {
+        const result = await client.get("/core/service/search");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_svc_control": {
+        const parsed = ServiceControlSchema.parse(args);
+        const result = await client.post(
+          `/core/service/${parsed.action}/${encodeURIComponent(parsed.service_name)}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown system tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,74 @@
+import axios from "axios";
+
+export class OPNsenseApiError extends Error {
+  readonly status: number | undefined;
+  readonly endpoint: string;
+  readonly details: string | undefined;
+
+  constructor(
+    message: string,
+    endpoint: string,
+    status?: number,
+    details?: string,
+  ) {
+    super(message);
+    this.name = "OPNsenseApiError";
+    this.endpoint = endpoint;
+    this.status = status;
+    this.details = details;
+  }
+}
+
+function sanitizeDetails(data: unknown): string | undefined {
+  if (data == null) return undefined;
+  if (typeof data === "string") return data;
+  if (typeof data === "object") {
+    return JSON.stringify(data);
+  }
+  return String(data);
+}
+
+export function extractError(
+  error: unknown,
+  endpoint: string,
+): OPNsenseApiError {
+  if (axios.isAxiosError(error)) {
+    const response = error.response;
+
+    if (response) {
+      const data = response.data as Record<string, unknown> | undefined;
+
+      const message =
+        typeof data?.message === "string"
+          ? data.message
+          : typeof data?.errorMessage === "string"
+            ? data.errorMessage
+            : `OPNsense API error: ${response.status} ${response.statusText}`;
+
+      const validations = data?.validations;
+      const details = validations
+        ? sanitizeDetails(validations)
+        : sanitizeDetails(data);
+
+      return new OPNsenseApiError(message, endpoint, response.status, details);
+    }
+
+    if (error.code === "ECONNREFUSED" || error.code === "ENOTFOUND" || error.code === "ETIMEDOUT") {
+      return new OPNsenseApiError(
+        `Network error: ${error.code} — unable to reach OPNsense API`,
+        endpoint,
+      );
+    }
+
+    return new OPNsenseApiError(
+      error.message || "Unknown network error",
+      endpoint,
+    );
+  }
+
+  if (error instanceof Error) {
+    return new OPNsenseApiError(error.message, endpoint);
+  }
+
+  return new OPNsenseApiError("Unknown error occurred", endpoint);
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export const UuidSchema = z
+  .string()
+  .uuid("Invalid UUID format");
+
+export const IpAddressSchema = z
+  .string()
+  .regex(
+    /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$/,
+    "Invalid IPv4 address",
+  );
+
+export const CidrSchema = z
+  .string()
+  .regex(
+    /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\/(?:3[0-2]|[12]?\d)$/,
+    "Invalid CIDR notation",
+  );
+
+export const HostnameSchema = z
+  .string()
+  .regex(
+    /^(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(?:\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*$/,
+    "Invalid hostname",
+  );
+
+export const PortSchema = z
+  .number()
+  .int()
+  .min(1, "Port must be at least 1")
+  .max(65535, "Port must be at most 65535");
+
+export const MacAddressSchema = z
+  .string()
+  .regex(
+    /^[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}$/,
+    "Invalid MAC address (expected format: AA:BB:CC:DD:EE:FF)",
+  );
+
+export const DomainSchema = z
+  .string()
+  .regex(
+    /^(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(?:\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*\.[a-zA-Z]{2,}$/,
+    "Invalid domain name",
+  );
+
+export const ProtocolSchema = z.enum(["TCP", "UDP", "ICMP", "any"]);
+
+export const FirewallActionSchema = z.enum(["pass", "block", "reject"]);
+
+export const DirectionSchema = z.enum(["in", "out"]);
+
+export const ServiceActionSchema = z.enum(["start", "stop", "restart"]);

--- a/tests/client/opnsense-client.test.ts
+++ b/tests/client/opnsense-client.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OPNsenseClient } from '../../src/client/opnsense-client.js';
+
+describe('OPNsenseClient', () => {
+  describe('fromEnv', () => {
+    beforeEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('creates client from environment variables', () => {
+      vi.stubEnv('OPNSENSE_URL', 'https://10.10.0.1');
+      vi.stubEnv('OPNSENSE_API_KEY', 'test-key');
+      vi.stubEnv('OPNSENSE_API_SECRET', 'test-secret');
+
+      const client = OPNsenseClient.fromEnv();
+      expect(client).toBeInstanceOf(OPNsenseClient);
+    });
+
+    it('throws when OPNSENSE_URL is missing', () => {
+      vi.stubEnv('OPNSENSE_API_KEY', 'test-key');
+      vi.stubEnv('OPNSENSE_API_SECRET', 'test-secret');
+      delete process.env.OPNSENSE_URL;
+
+      expect(() => OPNsenseClient.fromEnv()).toThrow('OPNSENSE_URL');
+    });
+
+    it('throws when OPNSENSE_API_KEY is missing', () => {
+      vi.stubEnv('OPNSENSE_URL', 'https://10.10.0.1');
+      vi.stubEnv('OPNSENSE_API_SECRET', 'test-secret');
+      delete process.env.OPNSENSE_API_KEY;
+
+      expect(() => OPNsenseClient.fromEnv()).toThrow('OPNSENSE_API_KEY');
+    });
+
+    it('throws when OPNSENSE_API_SECRET is missing', () => {
+      vi.stubEnv('OPNSENSE_URL', 'https://10.10.0.1');
+      vi.stubEnv('OPNSENSE_API_KEY', 'test-key');
+      delete process.env.OPNSENSE_API_SECRET;
+
+      expect(() => OPNsenseClient.fromEnv()).toThrow('OPNSENSE_API_SECRET');
+    });
+  });
+
+  describe('constructor', () => {
+    it('creates client with default SSL and timeout', () => {
+      const client = new OPNsenseClient({
+        url: 'https://10.10.0.1',
+        apiKey: 'key',
+        apiSecret: 'secret',
+      });
+      expect(client).toBeInstanceOf(OPNsenseClient);
+    });
+
+    it('creates client with custom SSL and timeout', () => {
+      const client = new OPNsenseClient({
+        url: 'https://10.10.0.1',
+        apiKey: 'key',
+        apiSecret: 'secret',
+        verifySsl: false,
+        timeout: 5000,
+      });
+      expect(client).toBeInstanceOf(OPNsenseClient);
+    });
+  });
+});

--- a/tests/tools/dns.test.ts
+++ b/tests/tools/dns.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import { dnsToolDefinitions, handleDnsTool } from '../../src/tools/dns.js';
+import type { OPNsenseClient } from '../../src/client/opnsense-client.js';
+
+function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
+  return {
+    get: vi.fn().mockResolvedValue({ rows: [] }),
+    post: vi.fn().mockResolvedValue({ uuid: 'test-uuid' }),
+    delete: vi.fn().mockResolvedValue({ status: 'ok' }),
+    ...overrides,
+  } as unknown as OPNsenseClient;
+}
+
+describe('DNS Tool Definitions', () => {
+  it('exports 12 tool definitions', () => {
+    expect(dnsToolDefinitions).toHaveLength(12);
+  });
+
+  it('all tools have opnsense_dns_ prefix', () => {
+    for (const tool of dnsToolDefinitions) {
+      expect(tool.name).toMatch(/^opnsense_dns_/);
+    }
+  });
+
+  it('all tools have descriptions', () => {
+    for (const tool of dnsToolDefinitions) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('all tools have inputSchema', () => {
+    for (const tool of dnsToolDefinitions) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe('object');
+    }
+  });
+});
+
+describe('handleDnsTool', () => {
+  it('lists overrides', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({ rows: [{ hostname: 'test', domain: 'local' }] }),
+    });
+
+    const result = await handleDnsTool('opnsense_dns_list_overrides', {}, client);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('test');
+    expect(client.get).toHaveBeenCalled();
+  });
+
+  it('adds an override with valid params', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ uuid: 'new-uuid' }),
+    });
+
+    const result = await handleDnsTool('opnsense_dns_add_override', {
+      hostname: 'myhost',
+      domain: 'local.lan',
+      server: '10.10.0.50',
+    }, client);
+
+    expect(result.content[0].text).toContain('new-uuid');
+    expect(client.post).toHaveBeenCalled();
+  });
+
+  it('deletes an override by UUID', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ result: 'deleted' }),
+    });
+
+    const result = await handleDnsTool('opnsense_dns_delete_override', {
+      uuid: '550e8400-e29b-41d4-a716-446655440000',
+    }, client);
+
+    expect(result.content[0].type).toBe('text');
+  });
+
+  it('applies DNS changes', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ status: 'ok' }),
+    });
+
+    const result = await handleDnsTool('opnsense_dns_apply', {}, client);
+    expect(result.content[0].text).toContain('ok');
+  });
+
+  it('returns error for unknown tool', async () => {
+    const client = mockClient();
+    const result = await handleDnsTool('opnsense_dns_nonexistent', {}, client);
+    expect(result.content[0].text).toContain('Unknown');
+  });
+
+  it('handles API errors gracefully', async () => {
+    const client = mockClient({
+      get: vi.fn().mockRejectedValue(new Error('Connection refused')),
+    });
+
+    const result = await handleDnsTool('opnsense_dns_list_overrides', {}, client);
+    expect(result.content[0].text).toContain('Error');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Slim OPNsense MCP Server with 41 granular tools across 6 domains
- DNS/Unbound (12), Firewall (8), Diagnostics (8), Interfaces (3), DHCP (5), System (5)
- Axios-based API client with Basic Auth, configurable SSL, Zod input validation
- stdio transport only, no SSH, no shell execution

## Test plan
- [x] `npm run build` — clean compile
- [x] `npm test` — 16/16 tests passing
- [x] Zod schema validation for all tool inputs
- [x] Error handling for API failures

Closes #1, closes #2, closes #3, closes #4, closes #5, closes #6, closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)