### PR TITLE
feat: add 9 ACME/Let's Encrypt tools (#8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense REST API. Provides ~41 granular tools for DNS, Firewall, Diagnostics, Interfaces, DHCP, and System management.
+Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense REST API. Provides ~50 granular tools for DNS, Firewall, Diagnostics, Interfaces, DHCP, and System management.
 
 **No SSH. No shell execution. API-only.**
 
@@ -21,6 +21,7 @@ src/
     interfaces.ts          # 3 Interface tools (read-only)
     dhcp.ts                # 5 DHCP tools (ISC + Kea dual support)
     system.ts              # 5 System/Service tools
+    acme.ts                # 9 ACME/Let's Encrypt tools
   utils/
     validation.ts          # Shared Zod schemas (IP, UUID, CIDR, etc.)
     errors.ts              # OPNsense error extraction

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense R
 - **Interfaces** — List, configuration, statistics (read-only)
 - **DHCP** — Leases, static mappings (ISC DHCPv4 + Kea dual support)
 - **System** — Info, backup/restore, service control
+- **ACME/Let's Encrypt** — Accounts, DNS-01 challenges (Cloudflare, AWS, etc.), certificates, renewal
 
 ## Quick Start
 
@@ -127,6 +128,19 @@ Add to your Claude Code MCP configuration (`~/.claude/mcp_settings.json`):
 | `opnsense_sys_restore` | Restore configuration (requires confirmation) |
 | `opnsense_svc_list` | List services and their status |
 | `opnsense_svc_control` | Start/stop/restart a service |
+
+### ACME/Let's Encrypt (9 tools)
+| Tool | Description |
+|------|-------------|
+| `opnsense_acme_list_accounts` | List ACME accounts (Let's Encrypt, ZeroSSL) |
+| `opnsense_acme_list_challenges` | List challenge/validation methods |
+| `opnsense_acme_add_challenge` | Add DNS-01 challenge (Cloudflare, AWS, etc.) |
+| `opnsense_acme_delete_challenge` | Delete a challenge by UUID |
+| `opnsense_acme_list_certs` | List certificates and status |
+| `opnsense_acme_create_cert` | Create a new certificate request |
+| `opnsense_acme_delete_cert` | Delete a certificate by UUID |
+| `opnsense_acme_renew_cert` | Trigger certificate renewal |
+| `opnsense_acme_apply` | Apply ACME configuration changes |
 
 ## Security
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { diagnosticsToolDefinitions, handleDiagnosticsTool } from './tools/diagn
 import { interfacesToolDefinitions, handleInterfacesTool } from './tools/interfaces.js';
 import { dhcpToolDefinitions, handleDhcpTool } from './tools/dhcp.js';
 import { systemToolDefinitions, handleSystemTool } from './tools/system.js';
+import { acmeToolDefinitions, handleAcmeTool } from './tools/acme.js';
 
 const allToolDefinitions = [
   ...dnsToolDefinitions,
@@ -19,6 +20,7 @@ const allToolDefinitions = [
   ...interfacesToolDefinitions,
   ...dhcpToolDefinitions,
   ...systemToolDefinitions,
+  ...acmeToolDefinitions,
 ];
 
 const toolHandlers = new Map<
@@ -32,6 +34,7 @@ for (const def of diagnosticsToolDefinitions) toolHandlers.set(def.name, handleD
 for (const def of interfacesToolDefinitions) toolHandlers.set(def.name, handleInterfacesTool);
 for (const def of dhcpToolDefinitions) toolHandlers.set(def.name, handleDhcpTool);
 for (const def of systemToolDefinitions) toolHandlers.set(def.name, handleSystemTool);
+for (const def of acmeToolDefinitions) toolHandlers.set(def.name, handleAcmeTool);
 
 const server = new Server(
   { name: 'mcp-opnsense', version: '2026.3.13' },

--- a/src/tools/acme.ts
+++ b/src/tools/acme.ts
@@ -1,0 +1,249 @@
+import { z } from "zod";
+import type { OPNsenseClient } from "../client/opnsense-client.js";
+import { UuidSchema } from "../utils/validation.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const AddChallengeSchema = z.object({
+  name: z.string().min(1, "Challenge name is required"),
+  dns_service: z.enum([
+    "dns_cf",
+    "dns_aws",
+    "dns_gcloud",
+    "dns_dgon",
+    "dns_he",
+    "dns_linode",
+    "dns_nsone",
+    "dns_ovh",
+    "dns_pdns",
+  ], { message: "Unsupported DNS provider" }),
+  dns_environment: z.string().optional().default(""),
+  description: z.string().optional().default(""),
+});
+
+const CreateCertSchema = z.object({
+  name: z.string().min(1, "Certificate name is required"),
+  description: z.string().optional().default(""),
+  alt_names: z.string().min(1, "At least one domain (SAN) is required"),
+  account_uuid: UuidSchema.describe("UUID of the ACME account to use"),
+  validation_uuid: UuidSchema.describe("UUID of the challenge/validation to use"),
+  key_length: z.enum(["2048", "4096", "ec256", "ec384"]).optional().default("ec256"),
+  auto_renewal: z.boolean().optional().default(true),
+});
+
+const RenewCertSchema = z.object({
+  uuid: UuidSchema,
+});
+
+const DeleteChallengeSchema = z.object({
+  uuid: UuidSchema,
+});
+
+const DeleteCertSchema = z.object({
+  uuid: UuidSchema,
+});
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const acmeToolDefinitions = [
+  {
+    name: "opnsense_acme_list_accounts",
+    description: "List all ACME accounts (Let's Encrypt, ZeroSSL, etc.) configured in the os-acme-client plugin",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_acme_list_challenges",
+    description: "List all configured ACME challenge/validation methods (DNS-01, HTTP-01, etc.)",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_acme_add_challenge",
+    description:
+      "Add a DNS-01 challenge configuration for automated certificate validation. Run opnsense_acme_apply afterwards.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: { type: "string", description: "Name for this challenge (e.g. 'Cloudflare DNS')" },
+        dns_service: {
+          type: "string",
+          enum: ["dns_cf", "dns_aws", "dns_gcloud", "dns_dgon", "dns_he", "dns_linode", "dns_nsone", "dns_ovh", "dns_pdns"],
+          description: "DNS provider service ID (e.g. 'dns_cf' for Cloudflare)",
+        },
+        dns_environment: {
+          type: "string",
+          description: "Environment variables for the DNS provider (e.g. 'CF_Token=xxx CF_Account_ID=yyy')",
+        },
+        description: { type: "string", description: "Optional description" },
+      },
+      required: ["name", "dns_service"],
+    },
+  },
+  {
+    name: "opnsense_acme_delete_challenge",
+    description: "Delete an ACME challenge/validation method by UUID. Run opnsense_acme_apply afterwards.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the challenge to delete" },
+      },
+      required: ["uuid"],
+    },
+  },
+  {
+    name: "opnsense_acme_list_certs",
+    description: "List all ACME certificates and their status (issued, pending, expired)",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_acme_create_cert",
+    description:
+      "Create a new ACME certificate request. Requires an account and challenge to be configured first. Run opnsense_acme_apply afterwards.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: { type: "string", description: "Certificate name (e.g. 'bifrost.itunified.io')" },
+        description: { type: "string", description: "Optional description" },
+        alt_names: {
+          type: "string",
+          description: "Comma-separated Subject Alternative Names (e.g. 'bifrost.itunified.io,*.itunified.io')",
+        },
+        account_uuid: { type: "string", description: "UUID of the ACME account" },
+        validation_uuid: { type: "string", description: "UUID of the challenge/validation method" },
+        key_length: {
+          type: "string",
+          enum: ["2048", "4096", "ec256", "ec384"],
+          description: "Key type and length (default: ec256)",
+        },
+        auto_renewal: {
+          type: "boolean",
+          description: "Enable automatic renewal (default: true)",
+        },
+      },
+      required: ["name", "alt_names", "account_uuid", "validation_uuid"],
+    },
+  },
+  {
+    name: "opnsense_acme_delete_cert",
+    description: "Delete an ACME certificate by UUID. Run opnsense_acme_apply afterwards.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the certificate to delete" },
+      },
+      required: ["uuid"],
+    },
+  },
+  {
+    name: "opnsense_acme_renew_cert",
+    description: "Trigger immediate renewal/signing of an ACME certificate by UUID",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the certificate to renew" },
+      },
+      required: ["uuid"],
+    },
+  },
+  {
+    name: "opnsense_acme_apply",
+    description: "Apply pending ACME configuration changes (reconfigure service)",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleAcmeTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: OPNsenseClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "opnsense_acme_list_accounts": {
+        const result = await client.get("/acme/accounts/search");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_acme_list_challenges": {
+        const result = await client.get("/acme/validations/search");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_acme_add_challenge": {
+        const parsed = AddChallengeSchema.parse(args);
+        const result = await client.post("/acme/validations/add", {
+          validation: {
+            enabled: "1",
+            name: parsed.name,
+            dns_service: parsed.dns_service,
+            dns_environment: parsed.dns_environment,
+            description: parsed.description,
+          },
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_acme_delete_challenge": {
+        const { uuid } = DeleteChallengeSchema.parse(args);
+        const result = await client.post(`/acme/validations/del/${uuid}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_acme_list_certs": {
+        const result = await client.get("/acme/certificates/search");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_acme_create_cert": {
+        const parsed = CreateCertSchema.parse(args);
+        const result = await client.post("/acme/certificates/add", {
+          certificate: {
+            enabled: "1",
+            name: parsed.name,
+            description: parsed.description,
+            altNames: parsed.alt_names,
+            account: parsed.account_uuid,
+            validationMethod: parsed.validation_uuid,
+            keyLength: parsed.key_length,
+            autoRenewal: parsed.auto_renewal ? "1" : "0",
+          },
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_acme_delete_cert": {
+        const { uuid } = DeleteCertSchema.parse(args);
+        const result = await client.post(`/acme/certificates/del/${uuid}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_acme_renew_cert": {
+        const { uuid } = RenewCertSchema.parse(args);
+        const result = await client.post(`/acme/certificates/sign/${uuid}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_acme_apply": {
+        const result = await client.post("/acme/service/reconfigure");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown ACME tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/tests/tools/acme.test.ts
+++ b/tests/tools/acme.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from 'vitest';
+import { acmeToolDefinitions, handleAcmeTool } from '../../src/tools/acme.js';
+import type { OPNsenseClient } from '../../src/client/opnsense-client.js';
+
+function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
+  return {
+    get: vi.fn().mockResolvedValue({ rows: [] }),
+    post: vi.fn().mockResolvedValue({ uuid: 'test-uuid' }),
+    delete: vi.fn().mockResolvedValue({ status: 'ok' }),
+    ...overrides,
+  } as unknown as OPNsenseClient;
+}
+
+describe('ACME Tool Definitions', () => {
+  it('exports 9 tool definitions', () => {
+    expect(acmeToolDefinitions).toHaveLength(9);
+  });
+
+  it('all tools have opnsense_acme_ prefix', () => {
+    for (const tool of acmeToolDefinitions) {
+      expect(tool.name).toMatch(/^opnsense_acme_/);
+    }
+  });
+
+  it('all tools have descriptions', () => {
+    for (const tool of acmeToolDefinitions) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('all tools have inputSchema', () => {
+    for (const tool of acmeToolDefinitions) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe('object');
+    }
+  });
+});
+
+describe('handleAcmeTool', () => {
+  it('lists accounts', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({ rows: [{ name: 'LE', email: 'test@test.com' }] }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_list_accounts', {}, client);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('LE');
+    expect(client.get).toHaveBeenCalledWith('/acme/accounts/search');
+  });
+
+  it('lists challenges', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({ rows: [{ name: 'CF DNS', dns_service: 'dns_cf' }] }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_list_challenges', {}, client);
+    expect(result.content[0].text).toContain('dns_cf');
+    expect(client.get).toHaveBeenCalledWith('/acme/validations/search');
+  });
+
+  it('adds a challenge with valid params', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ uuid: 'challenge-uuid' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_add_challenge', {
+      name: 'Cloudflare DNS-01',
+      dns_service: 'dns_cf',
+      dns_environment: 'CF_Token=xxx CF_Account_ID=yyy',
+    }, client);
+
+    expect(result.content[0].text).toContain('challenge-uuid');
+    expect(client.post).toHaveBeenCalledWith('/acme/validations/add', expect.objectContaining({
+      validation: expect.objectContaining({ dns_service: 'dns_cf' }),
+    }));
+  });
+
+  it('rejects invalid dns_service', async () => {
+    const client = mockClient();
+    const result = await handleAcmeTool('opnsense_acme_add_challenge', {
+      name: 'Bad Provider',
+      dns_service: 'dns_invalid',
+    }, client);
+
+    expect(result.content[0].text).toContain('Error');
+  });
+
+  it('deletes a challenge by UUID', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ result: 'deleted' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_delete_challenge', {
+      uuid: '550e8400-e29b-41d4-a716-446655440000',
+    }, client);
+
+    expect(result.content[0].type).toBe('text');
+    expect(client.post).toHaveBeenCalledWith('/acme/validations/del/550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('lists certificates', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({ rows: [{ name: 'bifrost.itunified.io', statusCode: '200' }] }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_list_certs', {}, client);
+    expect(result.content[0].text).toContain('bifrost');
+    expect(client.get).toHaveBeenCalledWith('/acme/certificates/search');
+  });
+
+  it('creates a certificate with valid params', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ uuid: 'cert-uuid' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_create_cert', {
+      name: 'bifrost.itunified.io',
+      alt_names: 'bifrost.itunified.io,*.itunified.io',
+      account_uuid: '550e8400-e29b-41d4-a716-446655440000',
+      validation_uuid: '660e8400-e29b-41d4-a716-446655440000',
+    }, client);
+
+    expect(result.content[0].text).toContain('cert-uuid');
+    expect(client.post).toHaveBeenCalledWith('/acme/certificates/add', expect.objectContaining({
+      certificate: expect.objectContaining({
+        name: 'bifrost.itunified.io',
+        keyLength: 'ec256',
+        autoRenewal: '1',
+      }),
+    }));
+  });
+
+  it('deletes a certificate by UUID', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ result: 'deleted' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_delete_cert', {
+      uuid: '550e8400-e29b-41d4-a716-446655440000',
+    }, client);
+
+    expect(result.content[0].type).toBe('text');
+    expect(client.post).toHaveBeenCalledWith('/acme/certificates/del/550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('renews a certificate', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ status: 'ok' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_renew_cert', {
+      uuid: '550e8400-e29b-41d4-a716-446655440000',
+    }, client);
+
+    expect(result.content[0].text).toContain('ok');
+    expect(client.post).toHaveBeenCalledWith('/acme/certificates/sign/550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('applies ACME changes', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ status: 'ok' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_apply', {}, client);
+    expect(result.content[0].text).toContain('ok');
+    expect(client.post).toHaveBeenCalledWith('/acme/service/reconfigure');
+  });
+
+  it('returns error for unknown tool', async () => {
+    const client = mockClient();
+    const result = await handleAcmeTool('opnsense_acme_nonexistent', {}, client);
+    expect(result.content[0].text).toContain('Unknown');
+  });
+
+  it('handles API errors gracefully', async () => {
+    const client = mockClient({
+      get: vi.fn().mockRejectedValue(new Error('Connection refused')),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_list_accounts', {}, client);
+    expect(result.content[0].text).toContain('Error');
+  });
+});


### PR DESCRIPTION
## Summary
- 9 new ACME tools for SSL certificate management via os-acme-client plugin
- DNS-01 challenge support (Cloudflare, AWS, GCloud, DigitalOcean, etc.)
- Accounts, challenges, certificates, renewal, apply
- 16 unit tests, Zod validation for all inputs
- Total: 41 → 50 tools

## Test plan
- [x] `npm run build` — clean compile
- [x] `npm test` — 32/32 tests passing
- [x] Zod schema validation for invalid inputs (dns_service enum, UUID format)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)