### PR TITLE
chore: add mandatory release workflow and update CHANGELOG (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,23 @@
 All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
-## Unreleased
+## v2026.03.13.2
 
-- Initial project setup
-- OPNsense API client (axios, Basic Auth, SSL)
-- DNS/Unbound tools (12 tools)
-- Firewall tools (8 tools)
-- Diagnostics tools (8 tools)
-- Interface tools (3 tools, read-only)
-- DHCP tools (5 tools, ISC + Kea dual support)
-- System tools (5 tools)
+- Add 9 ACME/Let's Encrypt tools with Cloudflare DNS-01 challenge support (#8)
+- Tools: list_accounts, list_challenges, add_challenge, delete_challenge, list_certs, create_cert, delete_cert, renew_cert, apply
+- DNS provider support: Cloudflare, AWS, GCloud, DigitalOcean, HE, Linode, NS1, OVH, PowerDNS
+- 16 unit tests for ACME tools
+- Total: 50 tools
+
+## v2026.03.13.1
+
+- Initial release with 41 granular MCP tools
+- OPNsense API client (axios, Basic Auth, configurable SSL)
+- DNS/Unbound tools (12 tools) — #2
+- Firewall tools (8 tools) — #3
+- Diagnostics tools (8 tools) — #4
+- Interface tools (3 tools, read-only) — #5
+- DHCP tools (5 tools, ISC + Kea dual support) — #6
+- System tools (5 tools) — #7
+- Shared Zod validation schemas (IP, UUID, CIDR, hostname, etc.)
+- 16 unit tests (client + DNS)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,21 @@ docs/
 - **Error handling**: No credential leaks in error messages
 - **Credentials**: Never hardcoded, never logged, never in git
 
-## Versioning (CalVer)
+## Versioning & Releases (CalVer)
 
 - Schema: `YYYY.MM.DD.TS` (e.g., `2026.03.13.1`)
 - `package.json`: npm-compatible without leading zeros (`2026.3.13`)
 - Git tags: `v2026.03.13.1` (leading zeros for sorting)
 - CHANGELOG.md: CalVer-based with date headers
+
+### Release Workflow — MANDATORY after every PR merge
+1. **Update CHANGELOG.md** with new version entry (CalVer date header, list of changes)
+2. Update `package.json` version if date changed
+3. Create annotated git tag: `git tag -a v2026.03.13.1 -m "v2026.03.13.1: <summary>"`
+4. Push tag: `git push origin --tags`
+5. Create GitHub release: `gh release create v2026.03.13.1 --title "v2026.03.13.1 — <title>" --notes "<release notes>"`
+6. Release notes must list what changed and reference closed issues
+7. **CHANGELOG.md is mandatory** — always keep it up to date, never skip it
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary
- Add mandatory release workflow (CHANGELOG → tag → GH release) to CLAUDE.md
- Update CHANGELOG.md from "Unreleased" to proper CalVer entries (v2026.03.13.1, v2026.03.13.2)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)