### PR TITLE
chore: elevate CHANGELOG.md to mandatory section (#13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,21 +59,26 @@ docs/
 - **Error handling**: No credential leaks in error messages
 - **Credentials**: Never hardcoded, never logged, never in git
 
+## CHANGELOG.md — MANDATORY
+
+- **`CHANGELOG.md` MUST exist and MUST be kept up to date**
+- **Every PR merge MUST add a new entry** before tagging/releasing
+- Format: CalVer date header (`## v2026.03.13.1`) followed by a list of changes with issue references
+- Never skip CHANGELOG updates — they are the source of truth for what changed and when
+
 ## Versioning & Releases (CalVer)
 
 - Schema: `YYYY.MM.DD.TS` (e.g., `2026.03.13.1`)
 - `package.json`: npm-compatible without leading zeros (`2026.3.13`)
 - Git tags: `v2026.03.13.1` (leading zeros for sorting)
-- CHANGELOG.md: CalVer-based with date headers
 
 ### Release Workflow — MANDATORY after every PR merge
-1. **Update CHANGELOG.md** with new version entry (CalVer date header, list of changes)
+1. **Update CHANGELOG.md** with new version entry
 2. Update `package.json` version if date changed
 3. Create annotated git tag: `git tag -a v2026.03.13.1 -m "v2026.03.13.1: <summary>"`
 4. Push tag: `git push origin --tags`
 5. Create GitHub release: `gh release create v2026.03.13.1 --title "v2026.03.13.1 — <title>" --notes "<release notes>"`
 6. Release notes must list what changed and reference closed issues
-7. **CHANGELOG.md is mandatory** — always keep it up to date, never skip it
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary
- CHANGELOG.md gets its own dedicated section in CLAUDE.md (not just a sub-point in release workflow)
- Explicit: CHANGELOG.md must exist and every PR merge must add an entry

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)