### PR TITLE
Add firmware/plugin management and ACME account tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.13.5
+
+- Add 5 firmware/plugin management tools: info, status, list_plugins, install, remove (#15)
+- Add 2 ACME account tools: add_account, delete_account (#15)
+- Support for 8 certificate authorities (Let's Encrypt, ZeroSSL, Buypass, SSL.com, Google, etc.)
+- 17 new unit tests (firmware + ACME account)
+- Total: 57 tools, 49 tests
+
 ## v2026.03.13.4
 
 - Elevate CHANGELOG.md to standalone mandatory section in CLAUDE.md (#13)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense REST API. Provides ~50 granular tools for DNS, Firewall, Diagnostics, Interfaces, DHCP, and System management.
+Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense REST API. Provides ~57 granular tools for DNS, Firewall, Diagnostics, Interfaces, DHCP, System, ACME, and Firmware management.
 
 **No SSH. No shell execution. API-only.**
 
@@ -21,7 +21,8 @@ src/
     interfaces.ts          # 3 Interface tools (read-only)
     dhcp.ts                # 5 DHCP tools (ISC + Kea dual support)
     system.ts              # 5 System/Service tools
-    acme.ts                # 9 ACME/Let's Encrypt tools
+    acme.ts                # 11 ACME/Let's Encrypt tools
+    firmware.ts            # 5 Firmware/Plugin management tools
   utils/
     validation.ts          # Shared Zod schemas (IP, UUID, CIDR, etc.)
     errors.ts              # OPNsense error extraction

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense R
 - **DHCP** — Leases, static mappings (ISC DHCPv4 + Kea dual support)
 - **System** — Info, backup/restore, service control
 - **ACME/Let's Encrypt** — Accounts, DNS-01 challenges (Cloudflare, AWS, etc.), certificates, renewal
+- **Firmware/Plugins** — System info, plugin management (install/remove)
 
 ## Quick Start
 
@@ -129,10 +130,12 @@ Add to your Claude Code MCP configuration (`~/.claude/mcp_settings.json`):
 | `opnsense_svc_list` | List services and their status |
 | `opnsense_svc_control` | Start/stop/restart a service |
 
-### ACME/Let's Encrypt (9 tools)
+### ACME/Let's Encrypt (11 tools)
 | Tool | Description |
 |------|-------------|
 | `opnsense_acme_list_accounts` | List ACME accounts (Let's Encrypt, ZeroSSL) |
+| `opnsense_acme_add_account` | Register a new ACME account |
+| `opnsense_acme_delete_account` | Delete an ACME account by UUID |
 | `opnsense_acme_list_challenges` | List challenge/validation methods |
 | `opnsense_acme_add_challenge` | Add DNS-01 challenge (Cloudflare, AWS, etc.) |
 | `opnsense_acme_delete_challenge` | Delete a challenge by UUID |
@@ -141,6 +144,15 @@ Add to your Claude Code MCP configuration (`~/.claude/mcp_settings.json`):
 | `opnsense_acme_delete_cert` | Delete a certificate by UUID |
 | `opnsense_acme_renew_cert` | Trigger certificate renewal |
 | `opnsense_acme_apply` | Apply ACME configuration changes |
+
+### Firmware/Plugins (5 tools)
+| Tool | Description |
+|------|-------------|
+| `opnsense_firmware_info` | Get firmware version and update status |
+| `opnsense_firmware_status` | Check firmware upgrade status |
+| `opnsense_firmware_list_plugins` | List available and installed plugins |
+| `opnsense_firmware_install` | Install a plugin package |
+| `opnsense_firmware_remove` | Remove a plugin package (requires confirmation) |
 
 ## Security
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { interfacesToolDefinitions, handleInterfacesTool } from './tools/interfa
 import { dhcpToolDefinitions, handleDhcpTool } from './tools/dhcp.js';
 import { systemToolDefinitions, handleSystemTool } from './tools/system.js';
 import { acmeToolDefinitions, handleAcmeTool } from './tools/acme.js';
+import { firmwareToolDefinitions, handleFirmwareTool } from './tools/firmware.js';
 
 const allToolDefinitions = [
   ...dnsToolDefinitions,
@@ -21,6 +22,7 @@ const allToolDefinitions = [
   ...dhcpToolDefinitions,
   ...systemToolDefinitions,
   ...acmeToolDefinitions,
+  ...firmwareToolDefinitions,
 ];
 
 const toolHandlers = new Map<
@@ -35,6 +37,7 @@ for (const def of interfacesToolDefinitions) toolHandlers.set(def.name, handleIn
 for (const def of dhcpToolDefinitions) toolHandlers.set(def.name, handleDhcpTool);
 for (const def of systemToolDefinitions) toolHandlers.set(def.name, handleSystemTool);
 for (const def of acmeToolDefinitions) toolHandlers.set(def.name, handleAcmeTool);
+for (const def of firmwareToolDefinitions) toolHandlers.set(def.name, handleFirmwareTool);
 
 const server = new Server(
   { name: 'mcp-opnsense', version: '2026.3.13' },

--- a/src/tools/acme.ts
+++ b/src/tools/acme.ts
@@ -45,6 +45,25 @@ const DeleteCertSchema = z.object({
   uuid: UuidSchema,
 });
 
+const AddAccountSchema = z.object({
+  name: z.string().min(1, "Account name is required"),
+  email: z.string().email("Valid email address is required"),
+  ca: z.enum([
+    "letsencrypt",
+    "letsencrypt-staging",
+    "zerossl",
+    "buypass",
+    "buypass-test",
+    "sslcom",
+    "google",
+    "googletest",
+  ], { message: "Unsupported certificate authority" }).optional().default("letsencrypt"),
+});
+
+const DeleteAccountSchema = z.object({
+  uuid: UuidSchema,
+});
+
 // ---------------------------------------------------------------------------
 // Tool definitions (for ListTools)
 // ---------------------------------------------------------------------------
@@ -54,6 +73,35 @@ export const acmeToolDefinitions = [
     name: "opnsense_acme_list_accounts",
     description: "List all ACME accounts (Let's Encrypt, ZeroSSL, etc.) configured in the os-acme-client plugin",
     inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_acme_add_account",
+    description:
+      "Register a new ACME account with a certificate authority (Let's Encrypt, ZeroSSL, etc.). Run opnsense_acme_apply afterwards.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: { type: "string", description: "Account name (e.g. 'Let\\'s Encrypt Production')" },
+        email: { type: "string", description: "Contact email address for the account" },
+        ca: {
+          type: "string",
+          enum: ["letsencrypt", "letsencrypt-staging", "zerossl", "buypass", "buypass-test", "sslcom", "google", "googletest"],
+          description: "Certificate authority (default: letsencrypt)",
+        },
+      },
+      required: ["name", "email"],
+    },
+  },
+  {
+    name: "opnsense_acme_delete_account",
+    description: "Delete an ACME account by UUID. Run opnsense_acme_apply afterwards.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the account to delete" },
+      },
+      required: ["uuid"],
+    },
   },
   {
     name: "opnsense_acme_list_challenges",
@@ -168,6 +216,25 @@ export async function handleAcmeTool(
     switch (name) {
       case "opnsense_acme_list_accounts": {
         const result = await client.get("/acme/accounts/search");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_acme_add_account": {
+        const parsed = AddAccountSchema.parse(args);
+        const result = await client.post("/acme/accounts/add", {
+          account: {
+            enabled: "1",
+            name: parsed.name,
+            email: parsed.email,
+            ca: parsed.ca,
+          },
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_acme_delete_account": {
+        const { uuid } = DeleteAccountSchema.parse(args);
+        const result = await client.post(`/acme/accounts/del/${uuid}`);
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 

--- a/src/tools/firmware.ts
+++ b/src/tools/firmware.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+import type { OPNsenseClient } from "../client/opnsense-client.js";
+
+// ---------------------------------------------------------------------------
+// Zod schemas for input validation
+// ---------------------------------------------------------------------------
+
+const PackageSchema = z.object({
+  package: z.string().min(1, "Package name is required"),
+});
+
+const RemovePackageSchema = z.object({
+  package: z.string().min(1, "Package name is required"),
+  confirm: z.literal(true, {
+    errorMap: () => ({ message: "confirm must be true to proceed with package removal" }),
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Tool definitions (for ListTools)
+// ---------------------------------------------------------------------------
+
+export const firmwareToolDefinitions = [
+  {
+    name: "opnsense_firmware_info",
+    description:
+      "Get firmware version, architecture, and update status of the OPNsense system",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_firmware_status",
+    description:
+      "Check for available firmware upgrades and their status (running, pending, done)",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_firmware_list_plugins",
+    description:
+      "List all available and installed OPNsense plugins with their versions and status",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_firmware_install",
+    description:
+      "Install an OPNsense plugin package by name (e.g. 'os-acme-client'). May require a service restart.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        package: {
+          type: "string",
+          description: "Plugin package name (e.g. 'os-acme-client', 'os-haproxy')",
+        },
+      },
+      required: ["package"],
+    },
+  },
+  {
+    name: "opnsense_firmware_remove",
+    description:
+      "Remove an installed OPNsense plugin package. DESTRUCTIVE: requires explicit confirmation.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        package: {
+          type: "string",
+          description: "Plugin package name to remove",
+        },
+        confirm: {
+          type: "boolean",
+          description: "Must be true to confirm the removal",
+          enum: [true],
+        },
+      },
+      required: ["package", "confirm"],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tool handler
+// ---------------------------------------------------------------------------
+
+export async function handleFirmwareTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: OPNsenseClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "opnsense_firmware_info": {
+        const result = await client.get("/core/firmware/info");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_firmware_status": {
+        const result = await client.get("/core/firmware/status");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_firmware_list_plugins": {
+        const result = await client.get("/core/firmware/info");
+        const info = result as Record<string, unknown>;
+        const plugins = (info.package ?? info.plugin ?? []) as unknown[];
+        return { content: [{ type: "text", text: JSON.stringify(plugins, null, 2) }] };
+      }
+
+      case "opnsense_firmware_install": {
+        const parsed = PackageSchema.parse(args);
+        const result = await client.post("/core/firmware/install/" + encodeURIComponent(parsed.package));
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_firmware_remove": {
+        const parsed = RemovePackageSchema.parse(args);
+        const result = await client.post("/core/firmware/remove/" + encodeURIComponent(parsed.package));
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown firmware tool: ${name}` }],
+        };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
+    };
+  }
+}

--- a/tests/tools/acme.test.ts
+++ b/tests/tools/acme.test.ts
@@ -12,8 +12,8 @@ function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
 }
 
 describe('ACME Tool Definitions', () => {
-  it('exports 9 tool definitions', () => {
-    expect(acmeToolDefinitions).toHaveLength(9);
+  it('exports 11 tool definitions', () => {
+    expect(acmeToolDefinitions).toHaveLength(11);
   });
 
   it('all tools have opnsense_acme_ prefix', () => {
@@ -165,6 +165,65 @@ describe('handleAcmeTool', () => {
     const result = await handleAcmeTool('opnsense_acme_apply', {}, client);
     expect(result.content[0].text).toContain('ok');
     expect(client.post).toHaveBeenCalledWith('/acme/service/reconfigure');
+  });
+
+  it('adds an ACME account with valid params', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ uuid: 'account-uuid' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_add_account', {
+      name: "Let's Encrypt Production",
+      email: 'admin@itunified.io',
+    }, client);
+
+    expect(result.content[0].text).toContain('account-uuid');
+    expect(client.post).toHaveBeenCalledWith('/acme/accounts/add', expect.objectContaining({
+      account: expect.objectContaining({
+        email: 'admin@itunified.io',
+        ca: 'letsencrypt',
+      }),
+    }));
+  });
+
+  it('adds an ACME account with custom CA', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ uuid: 'staging-uuid' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_add_account', {
+      name: 'LE Staging',
+      email: 'test@itunified.io',
+      ca: 'letsencrypt-staging',
+    }, client);
+
+    expect(result.content[0].text).toContain('staging-uuid');
+    expect(client.post).toHaveBeenCalledWith('/acme/accounts/add', expect.objectContaining({
+      account: expect.objectContaining({ ca: 'letsencrypt-staging' }),
+    }));
+  });
+
+  it('rejects add account with invalid email', async () => {
+    const client = mockClient();
+    const result = await handleAcmeTool('opnsense_acme_add_account', {
+      name: 'Bad Account',
+      email: 'not-an-email',
+    }, client);
+
+    expect(result.content[0].text).toContain('Error');
+  });
+
+  it('deletes an ACME account by UUID', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ result: 'deleted' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_delete_account', {
+      uuid: '550e8400-e29b-41d4-a716-446655440000',
+    }, client);
+
+    expect(result.content[0].type).toBe('text');
+    expect(client.post).toHaveBeenCalledWith('/acme/accounts/del/550e8400-e29b-41d4-a716-446655440000');
   });
 
   it('returns error for unknown tool', async () => {

--- a/tests/tools/firmware.test.ts
+++ b/tests/tools/firmware.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from 'vitest';
+import { firmwareToolDefinitions, handleFirmwareTool } from '../../src/tools/firmware.js';
+import type { OPNsenseClient } from '../../src/client/opnsense-client.js';
+
+function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
+  return {
+    get: vi.fn().mockResolvedValue({}),
+    post: vi.fn().mockResolvedValue({ status: 'ok' }),
+    delete: vi.fn().mockResolvedValue({ status: 'ok' }),
+    ...overrides,
+  } as unknown as OPNsenseClient;
+}
+
+describe('Firmware Tool Definitions', () => {
+  it('exports 5 tool definitions', () => {
+    expect(firmwareToolDefinitions).toHaveLength(5);
+  });
+
+  it('all tools have opnsense_firmware_ prefix', () => {
+    for (const tool of firmwareToolDefinitions) {
+      expect(tool.name).toMatch(/^opnsense_firmware_/);
+    }
+  });
+
+  it('all tools have descriptions', () => {
+    for (const tool of firmwareToolDefinitions) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('all tools have inputSchema', () => {
+    for (const tool of firmwareToolDefinitions) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe('object');
+    }
+  });
+});
+
+describe('handleFirmwareTool', () => {
+  it('gets firmware info', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({ product_version: '24.7', product_arch: 'amd64' }),
+    });
+
+    const result = await handleFirmwareTool('opnsense_firmware_info', {}, client);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('24.7');
+    expect(client.get).toHaveBeenCalledWith('/core/firmware/info');
+  });
+
+  it('gets firmware status', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({ status: 'done', status_msg: 'up to date' }),
+    });
+
+    const result = await handleFirmwareTool('opnsense_firmware_status', {}, client);
+    expect(result.content[0].text).toContain('done');
+    expect(client.get).toHaveBeenCalledWith('/core/firmware/status');
+  });
+
+  it('lists plugins from firmware info', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({
+        package: [
+          { name: 'os-acme-client', version: '4.5', installed: '1' },
+          { name: 'os-haproxy', version: '4.3', installed: '0' },
+        ],
+      }),
+    });
+
+    const result = await handleFirmwareTool('opnsense_firmware_list_plugins', {}, client);
+    expect(result.content[0].text).toContain('os-acme-client');
+    expect(result.content[0].text).toContain('os-haproxy');
+    expect(client.get).toHaveBeenCalledWith('/core/firmware/info');
+  });
+
+  it('installs a plugin package', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ status: 'ok' }),
+    });
+
+    const result = await handleFirmwareTool('opnsense_firmware_install', {
+      package: 'os-acme-client',
+    }, client);
+
+    expect(result.content[0].text).toContain('ok');
+    expect(client.post).toHaveBeenCalledWith('/core/firmware/install/os-acme-client');
+  });
+
+  it('removes a plugin package with confirmation', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ status: 'ok' }),
+    });
+
+    const result = await handleFirmwareTool('opnsense_firmware_remove', {
+      package: 'os-acme-client',
+      confirm: true,
+    }, client);
+
+    expect(result.content[0].text).toContain('ok');
+    expect(client.post).toHaveBeenCalledWith('/core/firmware/remove/os-acme-client');
+  });
+
+  it('rejects remove without confirmation', async () => {
+    const client = mockClient();
+    const result = await handleFirmwareTool('opnsense_firmware_remove', {
+      package: 'os-acme-client',
+      confirm: false,
+    }, client);
+
+    expect(result.content[0].text).toContain('Error');
+  });
+
+  it('rejects install with empty package name', async () => {
+    const client = mockClient();
+    const result = await handleFirmwareTool('opnsense_firmware_install', {
+      package: '',
+    }, client);
+
+    expect(result.content[0].text).toContain('Error');
+  });
+
+  it('returns error for unknown tool', async () => {
+    const client = mockClient();
+    const result = await handleFirmwareTool('opnsense_firmware_nonexistent', {}, client);
+    expect(result.content[0].text).toContain('Unknown');
+  });
+
+  it('handles API errors gracefully', async () => {
+    const client = mockClient({
+      get: vi.fn().mockRejectedValue(new Error('Connection refused')),
+    });
+
+    const result = await handleFirmwareTool('opnsense_firmware_info', {}, client);
+    expect(result.content[0].text).toContain('Error');
+    expect(result.content[0].text).toContain('Connection refused');
+  });
+});


### PR DESCRIPTION
## Summary
- 5 firmware/plugin management tools (`opnsense_firmware_info`, `status`, `list_plugins`, `install`, `remove`)
- 2 ACME account tools (`opnsense_acme_add_account`, `delete_account`)
- 8 certificate authority support (Let's Encrypt, ZeroSSL, Buypass, SSL.com, Google, etc.)
- 17 new unit tests (49 total)
- Total: 57 tools

Closes #15

## Test plan
- [x] `npm run build` — clean compilation
- [x] `npm test` — 49/49 tests pass
- [ ] Manual: verify firmware tools against OPNsense API
- [ ] Manual: verify ACME account tools against OPNsense API

🤖 Generated with [Claude Code](https://claude.com/claude-code)