### PR TITLE
Add mandatory design/plan doc workflow to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,14 @@ docs/
 - **Error handling**: No credential leaks in error messages
 - **Credentials**: Never hardcoded, never logged, never in git
 
+## Design/Plan Documents — MANDATORY
+
+- **Every significant change MUST have a design/plan document** in `docs/plans/`
+- Naming: `docs/plans/<NNN>-<short-description>.md`
+- The design doc MUST be referenced in the corresponding GitHub issue (bidirectional link)
+- Design docs contain: problem, solution, prerequisites, execution steps, rollback, verification
+- Trivial changes (typos, minor doc updates) are exempt
+
 ## CHANGELOG.md — MANDATORY
 
 - **`CHANGELOG.md` MUST exist and MUST be kept up to date**


### PR DESCRIPTION
## Summary
Add "Design/Plan Documents — MANDATORY" section to CLAUDE.md, consistent with infrastructure repo conventions.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)