### PR TITLE
fix: remove Content-Type header from GET/DELETE requests (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.13.7
+
+- Fix OPNsense API 400 errors on GET/DELETE requests caused by global Content-Type header (#19)
+- Add mandatory bug fix workflow to CLAUDE.md (#19)
+
 ## v2026.03.13.6
 
 - Add mandatory design/plan doc workflow to CLAUDE.md (#17)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,12 @@ docs/
 - **PR workflow**: feature branch -> `gh pr create` -> review -> merge into main
 - **After PR merge: branch/worktree cleanup is mandatory** — `git branch -d <branch>`, `git remote prune origin`, remove worktree. Prevents drift.
 
+### Bug Fixes — MANDATORY Workflow
+- **Every bug fix MUST have a GitHub issue** with appropriate labels (`bug`, scope labels)
+- Issue-first: create issue → branch (`fix/<issue-nr>-<description>`) → fix → PR → merge
+- Bug fix commits must reference the issue: `fix: <description> (#<nr>)`
+- CHANGELOG entry required for every bug fix
+
 ## Language
 
 - All documentation, code comments, commit messages: **English only**

--- a/src/client/opnsense-client.ts
+++ b/src/client/opnsense-client.ts
@@ -20,7 +20,6 @@ export class OPNsenseClient {
         rejectUnauthorized: config.verifySsl ?? true,
       }),
       headers: {
-        "Content-Type": "application/json",
         Accept: "application/json",
       },
     });
@@ -37,7 +36,9 @@ export class OPNsenseClient {
 
   async post<T>(path: string, data?: unknown): Promise<T> {
     try {
-      const response = await this.http.post<T>(path, data ?? {});
+      const response = await this.http.post<T>(path, data ?? {}, {
+        headers: { "Content-Type": "application/json" },
+      });
       return response.data;
     } catch (error: unknown) {
       throw extractError(error, `POST ${path}`);


### PR DESCRIPTION
## Summary

- Remove global `Content-Type: application/json` header from axios instance — OPNsense API rejects GET/DELETE requests that include it (400 Bad Request)
- Add `Content-Type` only to POST requests where it's needed
- Add mandatory bug fix workflow to CLAUDE.md

Closes #19

## Test plan

- [x] All 49 unit tests pass (`npm test`)
- [x] TypeScript builds cleanly (`npm run build`)
- [ ] Verify MCP tools return real data after rebuild (no more 400 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)