### PR TITLE
fix: correct ACME API path prefix /acme/ → /acmeclient/ (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.13.8
+
+- Fix ACME API path prefix from `/acme/` to `/acmeclient/` matching os-acme-client plugin (#21)
+
 ## v2026.03.13.7
 
 - Fix OPNsense API 400 errors on GET/DELETE requests caused by global Content-Type header (#19)

--- a/src/tools/acme.ts
+++ b/src/tools/acme.ts
@@ -215,13 +215,13 @@ export async function handleAcmeTool(
   try {
     switch (name) {
       case "opnsense_acme_list_accounts": {
-        const result = await client.get("/acme/accounts/search");
+        const result = await client.get("/acmeclient/accounts/search");
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
       case "opnsense_acme_add_account": {
         const parsed = AddAccountSchema.parse(args);
-        const result = await client.post("/acme/accounts/add", {
+        const result = await client.post("/acmeclient/accounts/add", {
           account: {
             enabled: "1",
             name: parsed.name,
@@ -234,18 +234,18 @@ export async function handleAcmeTool(
 
       case "opnsense_acme_delete_account": {
         const { uuid } = DeleteAccountSchema.parse(args);
-        const result = await client.post(`/acme/accounts/del/${uuid}`);
+        const result = await client.post(`/acmeclient/accounts/del/${uuid}`);
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
       case "opnsense_acme_list_challenges": {
-        const result = await client.get("/acme/validations/search");
+        const result = await client.get("/acmeclient/validations/search");
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
       case "opnsense_acme_add_challenge": {
         const parsed = AddChallengeSchema.parse(args);
-        const result = await client.post("/acme/validations/add", {
+        const result = await client.post("/acmeclient/validations/add", {
           validation: {
             enabled: "1",
             name: parsed.name,
@@ -259,18 +259,18 @@ export async function handleAcmeTool(
 
       case "opnsense_acme_delete_challenge": {
         const { uuid } = DeleteChallengeSchema.parse(args);
-        const result = await client.post(`/acme/validations/del/${uuid}`);
+        const result = await client.post(`/acmeclient/validations/del/${uuid}`);
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
       case "opnsense_acme_list_certs": {
-        const result = await client.get("/acme/certificates/search");
+        const result = await client.get("/acmeclient/certificates/search");
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
       case "opnsense_acme_create_cert": {
         const parsed = CreateCertSchema.parse(args);
-        const result = await client.post("/acme/certificates/add", {
+        const result = await client.post("/acmeclient/certificates/add", {
           certificate: {
             enabled: "1",
             name: parsed.name,
@@ -287,18 +287,18 @@ export async function handleAcmeTool(
 
       case "opnsense_acme_delete_cert": {
         const { uuid } = DeleteCertSchema.parse(args);
-        const result = await client.post(`/acme/certificates/del/${uuid}`);
+        const result = await client.post(`/acmeclient/certificates/del/${uuid}`);
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
       case "opnsense_acme_renew_cert": {
         const { uuid } = RenewCertSchema.parse(args);
-        const result = await client.post(`/acme/certificates/sign/${uuid}`);
+        const result = await client.post(`/acmeclient/certificates/sign/${uuid}`);
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
       case "opnsense_acme_apply": {
-        const result = await client.post("/acme/service/reconfigure");
+        const result = await client.post("/acmeclient/service/reconfigure");
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 

--- a/tests/tools/acme.test.ts
+++ b/tests/tools/acme.test.ts
@@ -46,7 +46,7 @@ describe('handleAcmeTool', () => {
     const result = await handleAcmeTool('opnsense_acme_list_accounts', {}, client);
     expect(result.content[0].type).toBe('text');
     expect(result.content[0].text).toContain('LE');
-    expect(client.get).toHaveBeenCalledWith('/acme/accounts/search');
+    expect(client.get).toHaveBeenCalledWith('/acmeclient/accounts/search');
   });
 
   it('lists challenges', async () => {
@@ -56,7 +56,7 @@ describe('handleAcmeTool', () => {
 
     const result = await handleAcmeTool('opnsense_acme_list_challenges', {}, client);
     expect(result.content[0].text).toContain('dns_cf');
-    expect(client.get).toHaveBeenCalledWith('/acme/validations/search');
+    expect(client.get).toHaveBeenCalledWith('/acmeclient/validations/search');
   });
 
   it('adds a challenge with valid params', async () => {
@@ -71,7 +71,7 @@ describe('handleAcmeTool', () => {
     }, client);
 
     expect(result.content[0].text).toContain('challenge-uuid');
-    expect(client.post).toHaveBeenCalledWith('/acme/validations/add', expect.objectContaining({
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/validations/add', expect.objectContaining({
       validation: expect.objectContaining({ dns_service: 'dns_cf' }),
     }));
   });
@@ -96,7 +96,7 @@ describe('handleAcmeTool', () => {
     }, client);
 
     expect(result.content[0].type).toBe('text');
-    expect(client.post).toHaveBeenCalledWith('/acme/validations/del/550e8400-e29b-41d4-a716-446655440000');
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/validations/del/550e8400-e29b-41d4-a716-446655440000');
   });
 
   it('lists certificates', async () => {
@@ -106,7 +106,7 @@ describe('handleAcmeTool', () => {
 
     const result = await handleAcmeTool('opnsense_acme_list_certs', {}, client);
     expect(result.content[0].text).toContain('bifrost');
-    expect(client.get).toHaveBeenCalledWith('/acme/certificates/search');
+    expect(client.get).toHaveBeenCalledWith('/acmeclient/certificates/search');
   });
 
   it('creates a certificate with valid params', async () => {
@@ -122,7 +122,7 @@ describe('handleAcmeTool', () => {
     }, client);
 
     expect(result.content[0].text).toContain('cert-uuid');
-    expect(client.post).toHaveBeenCalledWith('/acme/certificates/add', expect.objectContaining({
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/certificates/add', expect.objectContaining({
       certificate: expect.objectContaining({
         name: 'bifrost.itunified.io',
         keyLength: 'ec256',
@@ -141,7 +141,7 @@ describe('handleAcmeTool', () => {
     }, client);
 
     expect(result.content[0].type).toBe('text');
-    expect(client.post).toHaveBeenCalledWith('/acme/certificates/del/550e8400-e29b-41d4-a716-446655440000');
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/certificates/del/550e8400-e29b-41d4-a716-446655440000');
   });
 
   it('renews a certificate', async () => {
@@ -154,7 +154,7 @@ describe('handleAcmeTool', () => {
     }, client);
 
     expect(result.content[0].text).toContain('ok');
-    expect(client.post).toHaveBeenCalledWith('/acme/certificates/sign/550e8400-e29b-41d4-a716-446655440000');
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/certificates/sign/550e8400-e29b-41d4-a716-446655440000');
   });
 
   it('applies ACME changes', async () => {
@@ -164,7 +164,7 @@ describe('handleAcmeTool', () => {
 
     const result = await handleAcmeTool('opnsense_acme_apply', {}, client);
     expect(result.content[0].text).toContain('ok');
-    expect(client.post).toHaveBeenCalledWith('/acme/service/reconfigure');
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/service/reconfigure');
   });
 
   it('adds an ACME account with valid params', async () => {
@@ -178,7 +178,7 @@ describe('handleAcmeTool', () => {
     }, client);
 
     expect(result.content[0].text).toContain('account-uuid');
-    expect(client.post).toHaveBeenCalledWith('/acme/accounts/add', expect.objectContaining({
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/accounts/add', expect.objectContaining({
       account: expect.objectContaining({
         email: 'admin@itunified.io',
         ca: 'letsencrypt',
@@ -198,7 +198,7 @@ describe('handleAcmeTool', () => {
     }, client);
 
     expect(result.content[0].text).toContain('staging-uuid');
-    expect(client.post).toHaveBeenCalledWith('/acme/accounts/add', expect.objectContaining({
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/accounts/add', expect.objectContaining({
       account: expect.objectContaining({ ca: 'letsencrypt-staging' }),
     }));
   });
@@ -223,7 +223,7 @@ describe('handleAcmeTool', () => {
     }, client);
 
     expect(result.content[0].type).toBe('text');
-    expect(client.post).toHaveBeenCalledWith('/acme/accounts/del/550e8400-e29b-41d4-a716-446655440000');
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/accounts/del/550e8400-e29b-41d4-a716-446655440000');
   });
 
   it('returns error for unknown tool', async () => {


### PR DESCRIPTION
## Summary

- Fix all 11 ACME tool API paths from `/acme/` to `/acmeclient/`
- The os-acme-client plugin registers under `/acmeclient/`, not `/acme/`
- All ACME tools were returning "Endpoint not found"

Closes #21

## Test plan

- [x] All 49 unit tests pass
- [x] TypeScript builds cleanly
- [ ] Verify ACME MCP tools work against live OPNsense after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)