### PR TITLE
fix: ACME tool bugs and new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.13.9
+
+- Fix keyLength mapping: `ec256` → `key_ec256`, `ec384` → `key_ec384` for OPNsense API (#23)
+- Fix ACME challenge tool: add provider-specific credential fields (dns_cf_token, dns_cf_account_id, etc.) (#24)
+- Fix ACME validation update: use `/update/` endpoint instead of `/set/` which silently drops data (#25)
+- Fix ACME settings: use correct `acmeclient` wrapper key for settings API (#26)
+- Add `opnsense_acme_settings` tool: get/update ACME service settings (enable, environment, log level) (#27)
+- Add `opnsense_acme_register_account` tool: trigger account registration with CA (#28)
+- Add `opnsense_acme_update_challenge` tool: update existing challenge configurations (#25)
+- Total: 60 tools, 56 tests
+
 ## v2026.03.13.8
 
 - Fix ACME API path prefix from `/acme/` to `/acmeclient/` matching os-acme-client plugin (#21)

--- a/src/tools/acme.ts
+++ b/src/tools/acme.ts
@@ -3,6 +3,29 @@ import type { OPNsenseClient } from "../client/opnsense-client.js";
 import { UuidSchema } from "../utils/validation.js";
 
 // ---------------------------------------------------------------------------
+// Key length mapping: user-facing values → OPNsense API values
+// ---------------------------------------------------------------------------
+
+const KEY_LENGTH_MAP: Record<string, string> = {
+  "2048": "2048",
+  "4096": "4096",
+  ec256: "key_ec256",
+  ec384: "key_ec384",
+};
+
+// ---------------------------------------------------------------------------
+// Cloudflare DNS credential fields (dns_cf)
+// ---------------------------------------------------------------------------
+
+const CloudflareDnsFields = z.object({
+  dns_cf_token: z.string().optional().describe("Cloudflare API Token (recommended)"),
+  dns_cf_account_id: z.string().optional().describe("Cloudflare Account ID (used with API Token)"),
+  dns_cf_key: z.string().optional().describe("Cloudflare Global API Key (legacy)"),
+  dns_cf_email: z.string().optional().describe("Cloudflare account email (used with Global API Key)"),
+  dns_cf_zone_id: z.string().optional().describe("Cloudflare Zone ID (optional, speeds up DNS operations)"),
+});
+
+// ---------------------------------------------------------------------------
 // Zod schemas for input validation
 // ---------------------------------------------------------------------------
 
@@ -21,6 +44,36 @@ const AddChallengeSchema = z.object({
   ], { message: "Unsupported DNS provider" }),
   dns_environment: z.string().optional().default(""),
   description: z.string().optional().default(""),
+  // Cloudflare-specific credential fields
+  dns_cf_token: z.string().optional(),
+  dns_cf_account_id: z.string().optional(),
+  dns_cf_key: z.string().optional(),
+  dns_cf_email: z.string().optional(),
+  dns_cf_zone_id: z.string().optional(),
+});
+
+const UpdateChallengeSchema = z.object({
+  uuid: UuidSchema,
+  name: z.string().optional(),
+  dns_service: z.enum([
+    "dns_cf",
+    "dns_aws",
+    "dns_gcloud",
+    "dns_dgon",
+    "dns_he",
+    "dns_linode",
+    "dns_nsone",
+    "dns_ovh",
+    "dns_pdns",
+  ], { message: "Unsupported DNS provider" }).optional(),
+  dns_environment: z.string().optional(),
+  description: z.string().optional(),
+  // Cloudflare-specific credential fields
+  dns_cf_token: z.string().optional(),
+  dns_cf_account_id: z.string().optional(),
+  dns_cf_key: z.string().optional(),
+  dns_cf_email: z.string().optional(),
+  dns_cf_zone_id: z.string().optional(),
 });
 
 const CreateCertSchema = z.object({
@@ -64,6 +117,36 @@ const DeleteAccountSchema = z.object({
   uuid: UuidSchema,
 });
 
+const RegisterAccountSchema = z.object({
+  uuid: UuidSchema,
+});
+
+const AcmeSettingsSchema = z.object({
+  enabled: z.enum(["0", "1"]).optional(),
+  environment: z.enum(["prod", "stg"]).optional(),
+  autoRenewal: z.enum(["0", "1"]).optional(),
+  logLevel: z.enum(["normal", "extended", "debug"]).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Helper: extract provider credential fields from parsed args
+// ---------------------------------------------------------------------------
+
+function extractProviderFields(
+  parsed: Record<string, unknown>,
+  dns_service: string,
+): Record<string, string> {
+  const fields: Record<string, string> = {};
+  if (dns_service === "dns_cf") {
+    if (parsed.dns_cf_token) fields.dns_cf_token = String(parsed.dns_cf_token);
+    if (parsed.dns_cf_account_id) fields.dns_cf_account_id = String(parsed.dns_cf_account_id);
+    if (parsed.dns_cf_key) fields.dns_cf_key = String(parsed.dns_cf_key);
+    if (parsed.dns_cf_email) fields.dns_cf_email = String(parsed.dns_cf_email);
+    if (parsed.dns_cf_zone_id) fields.dns_cf_zone_id = String(parsed.dns_cf_zone_id);
+  }
+  return fields;
+}
+
 // ---------------------------------------------------------------------------
 // Tool definitions (for ListTools)
 // ---------------------------------------------------------------------------
@@ -104,6 +187,17 @@ export const acmeToolDefinitions = [
     },
   },
   {
+    name: "opnsense_acme_register_account",
+    description: "Trigger registration of an ACME account with its certificate authority. Use after adding an account to verify it registers successfully.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the account to register" },
+      },
+      required: ["uuid"],
+    },
+  },
+  {
     name: "opnsense_acme_list_challenges",
     description: "List all configured ACME challenge/validation methods (DNS-01, HTTP-01, etc.)",
     inputSchema: { type: "object" as const, properties: {} },
@@ -111,7 +205,7 @@ export const acmeToolDefinitions = [
   {
     name: "opnsense_acme_add_challenge",
     description:
-      "Add a DNS-01 challenge configuration for automated certificate validation. Run opnsense_acme_apply afterwards.",
+      "Add a DNS-01 challenge configuration for automated certificate validation. For Cloudflare, use the dedicated dns_cf_* fields instead of dns_environment. Run opnsense_acme_apply afterwards.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -123,11 +217,41 @@ export const acmeToolDefinitions = [
         },
         dns_environment: {
           type: "string",
-          description: "Environment variables for the DNS provider (e.g. 'CF_Token=xxx CF_Account_ID=yyy')",
+          description: "Environment variables for the DNS provider (for non-Cloudflare providers or custom env vars)",
         },
         description: { type: "string", description: "Optional description" },
+        dns_cf_token: { type: "string", description: "Cloudflare API Token (recommended over Global API Key)" },
+        dns_cf_account_id: { type: "string", description: "Cloudflare Account ID (used with API Token)" },
+        dns_cf_key: { type: "string", description: "Cloudflare Global API Key (legacy, use dns_cf_token instead)" },
+        dns_cf_email: { type: "string", description: "Cloudflare account email (used with Global API Key)" },
+        dns_cf_zone_id: { type: "string", description: "Cloudflare Zone ID (optional, speeds up DNS operations)" },
       },
       required: ["name", "dns_service"],
+    },
+  },
+  {
+    name: "opnsense_acme_update_challenge",
+    description:
+      "Update an existing ACME challenge/validation by UUID. Use to change credentials or settings. Run opnsense_acme_apply afterwards.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "UUID of the challenge to update" },
+        name: { type: "string", description: "Updated name" },
+        dns_service: {
+          type: "string",
+          enum: ["dns_cf", "dns_aws", "dns_gcloud", "dns_dgon", "dns_he", "dns_linode", "dns_nsone", "dns_ovh", "dns_pdns"],
+          description: "DNS provider service ID",
+        },
+        dns_environment: { type: "string", description: "Environment variables" },
+        description: { type: "string", description: "Updated description" },
+        dns_cf_token: { type: "string", description: "Cloudflare API Token" },
+        dns_cf_account_id: { type: "string", description: "Cloudflare Account ID" },
+        dns_cf_key: { type: "string", description: "Cloudflare Global API Key" },
+        dns_cf_email: { type: "string", description: "Cloudflare account email" },
+        dns_cf_zone_id: { type: "string", description: "Cloudflare Zone ID" },
+      },
+      required: ["uuid"],
     },
   },
   {
@@ -197,6 +321,19 @@ export const acmeToolDefinitions = [
     },
   },
   {
+    name: "opnsense_acme_settings",
+    description: "Get or update ACME service settings (enable/disable, environment, auto-renewal, log level). When called with no parameters, returns current settings. Run opnsense_acme_apply afterwards when updating.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        enabled: { type: "string", enum: ["0", "1"], description: "Enable (1) or disable (0) the ACME service" },
+        environment: { type: "string", enum: ["prod", "stg"], description: "ACME environment: prod (production) or stg (staging)" },
+        autoRenewal: { type: "string", enum: ["0", "1"], description: "Enable (1) or disable (0) automatic certificate renewal" },
+        logLevel: { type: "string", enum: ["normal", "extended", "debug"], description: "Log verbosity level" },
+      },
+    },
+  },
+  {
     name: "opnsense_acme_apply",
     description: "Apply pending ACME configuration changes (reconfigure service)",
     inputSchema: { type: "object" as const, properties: {} },
@@ -238,6 +375,12 @@ export async function handleAcmeTool(
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
+      case "opnsense_acme_register_account": {
+        const { uuid } = RegisterAccountSchema.parse(args);
+        const result = await client.post(`/acmeclient/accounts/register/${uuid}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
       case "opnsense_acme_list_challenges": {
         const result = await client.get("/acmeclient/validations/search");
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
@@ -245,6 +388,7 @@ export async function handleAcmeTool(
 
       case "opnsense_acme_add_challenge": {
         const parsed = AddChallengeSchema.parse(args);
+        const providerFields = extractProviderFields(parsed, parsed.dns_service);
         const result = await client.post("/acmeclient/validations/add", {
           validation: {
             enabled: "1",
@@ -252,7 +396,28 @@ export async function handleAcmeTool(
             dns_service: parsed.dns_service,
             dns_environment: parsed.dns_environment,
             description: parsed.description,
+            ...providerFields,
           },
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_acme_update_challenge": {
+        const parsed = UpdateChallengeSchema.parse(args);
+        const { uuid, ...rest } = parsed;
+        const dns_service = rest.dns_service ?? "dns_cf";
+        const providerFields = extractProviderFields(rest, dns_service);
+        const validation: Record<string, string> = {};
+        if (rest.name !== undefined) validation.name = rest.name;
+        if (rest.dns_service !== undefined) validation.dns_service = rest.dns_service;
+        if (rest.dns_environment !== undefined) validation.dns_environment = rest.dns_environment;
+        if (rest.description !== undefined) validation.description = rest.description;
+        Object.assign(validation, providerFields);
+
+        // IMPORTANT: OPNsense ValidationsController uses updateAction(), NOT setAction()
+        // The /set/ endpoint silently returns success without persisting data (#25)
+        const result = await client.post(`/acmeclient/validations/update/${uuid}`, {
+          validation,
         });
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
@@ -270,6 +435,8 @@ export async function handleAcmeTool(
 
       case "opnsense_acme_create_cert": {
         const parsed = CreateCertSchema.parse(args);
+        // Map user-facing key_length to OPNsense API value (#23)
+        const apiKeyLength = KEY_LENGTH_MAP[parsed.key_length] ?? parsed.key_length;
         const result = await client.post("/acmeclient/certificates/add", {
           certificate: {
             enabled: "1",
@@ -278,7 +445,7 @@ export async function handleAcmeTool(
             altNames: parsed.alt_names,
             account: parsed.account_uuid,
             validationMethod: parsed.validation_uuid,
-            keyLength: parsed.key_length,
+            keyLength: apiKeyLength,
             autoRenewal: parsed.auto_renewal ? "1" : "0",
           },
         });
@@ -294,6 +461,32 @@ export async function handleAcmeTool(
       case "opnsense_acme_renew_cert": {
         const { uuid } = RenewCertSchema.parse(args);
         const result = await client.post(`/acmeclient/certificates/sign/${uuid}`);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_acme_settings": {
+        const parsed = AcmeSettingsSchema.parse(args);
+        const hasUpdates = parsed.enabled !== undefined ||
+          parsed.environment !== undefined ||
+          parsed.autoRenewal !== undefined ||
+          parsed.logLevel !== undefined;
+
+        if (!hasUpdates) {
+          // GET current settings
+          const result = await client.get("/acmeclient/settings/get");
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        }
+
+        // Update settings with correct wrapper key (#26)
+        const settings: Record<string, string> = {};
+        if (parsed.enabled !== undefined) settings.enabled = parsed.enabled;
+        if (parsed.environment !== undefined) settings.environment = parsed.environment;
+        if (parsed.autoRenewal !== undefined) settings.autoRenewal = parsed.autoRenewal;
+        if (parsed.logLevel !== undefined) settings.logLevel = parsed.logLevel;
+
+        const result = await client.post("/acmeclient/settings/set", {
+          acmeclient: { settings },
+        });
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 

--- a/tests/tools/acme.test.ts
+++ b/tests/tools/acme.test.ts
@@ -12,8 +12,8 @@ function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
 }
 
 describe('ACME Tool Definitions', () => {
-  it('exports 11 tool definitions', () => {
-    expect(acmeToolDefinitions).toHaveLength(11);
+  it('exports 14 tool definitions', () => {
+    expect(acmeToolDefinitions).toHaveLength(14);
   });
 
   it('all tools have opnsense_acme_ prefix', () => {
@@ -59,7 +59,7 @@ describe('handleAcmeTool', () => {
     expect(client.get).toHaveBeenCalledWith('/acmeclient/validations/search');
   });
 
-  it('adds a challenge with valid params', async () => {
+  it('adds a challenge with Cloudflare credential fields', async () => {
     const client = mockClient({
       post: vi.fn().mockResolvedValue({ uuid: 'challenge-uuid' }),
     });
@@ -67,12 +67,37 @@ describe('handleAcmeTool', () => {
     const result = await handleAcmeTool('opnsense_acme_add_challenge', {
       name: 'Cloudflare DNS-01',
       dns_service: 'dns_cf',
-      dns_environment: 'CF_Token=xxx CF_Account_ID=yyy',
+      dns_cf_token: 'my-cf-token',
+      dns_cf_account_id: 'my-account-id',
     }, client);
 
     expect(result.content[0].text).toContain('challenge-uuid');
     expect(client.post).toHaveBeenCalledWith('/acmeclient/validations/add', expect.objectContaining({
-      validation: expect.objectContaining({ dns_service: 'dns_cf' }),
+      validation: expect.objectContaining({
+        dns_service: 'dns_cf',
+        dns_cf_token: 'my-cf-token',
+        dns_cf_account_id: 'my-account-id',
+      }),
+    }));
+  });
+
+  it('adds a challenge without provider fields (backward compat)', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ uuid: 'challenge-uuid' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_add_challenge', {
+      name: 'AWS DNS',
+      dns_service: 'dns_aws',
+      dns_environment: 'AWS_ACCESS_KEY_ID=xxx AWS_SECRET_ACCESS_KEY=yyy',
+    }, client);
+
+    expect(result.content[0].text).toContain('challenge-uuid');
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/validations/add', expect.objectContaining({
+      validation: expect.objectContaining({
+        dns_service: 'dns_aws',
+        dns_environment: 'AWS_ACCESS_KEY_ID=xxx AWS_SECRET_ACCESS_KEY=yyy',
+      }),
     }));
   });
 
@@ -84,6 +109,30 @@ describe('handleAcmeTool', () => {
     }, client);
 
     expect(result.content[0].text).toContain('Error');
+  });
+
+  it('updates a challenge using /update/ endpoint (not /set/)', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ result: 'saved' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_update_challenge', {
+      uuid: '550e8400-e29b-41d4-a716-446655440000',
+      dns_cf_token: 'new-token',
+      dns_cf_account_id: 'new-account-id',
+    }, client);
+
+    expect(result.content[0].text).toContain('saved');
+    // CRITICAL: must use /update/ not /set/ (#25)
+    expect(client.post).toHaveBeenCalledWith(
+      '/acmeclient/validations/update/550e8400-e29b-41d4-a716-446655440000',
+      expect.objectContaining({
+        validation: expect.objectContaining({
+          dns_cf_token: 'new-token',
+          dns_cf_account_id: 'new-account-id',
+        }),
+      }),
+    );
   });
 
   it('deletes a challenge by UUID', async () => {
@@ -109,7 +158,7 @@ describe('handleAcmeTool', () => {
     expect(client.get).toHaveBeenCalledWith('/acmeclient/certificates/search');
   });
 
-  it('creates a certificate with valid params', async () => {
+  it('creates a certificate with correct keyLength mapping (#23)', async () => {
     const client = mockClient({
       post: vi.fn().mockResolvedValue({ uuid: 'cert-uuid' }),
     });
@@ -125,8 +174,48 @@ describe('handleAcmeTool', () => {
     expect(client.post).toHaveBeenCalledWith('/acmeclient/certificates/add', expect.objectContaining({
       certificate: expect.objectContaining({
         name: 'bifrost.itunified.io',
-        keyLength: 'ec256',
+        keyLength: 'key_ec256', // mapped from ec256 → key_ec256
         autoRenewal: '1',
+      }),
+    }));
+  });
+
+  it('maps ec384 to key_ec384', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ uuid: 'cert-uuid' }),
+    });
+
+    await handleAcmeTool('opnsense_acme_create_cert', {
+      name: 'test.example.com',
+      alt_names: 'test.example.com',
+      account_uuid: '550e8400-e29b-41d4-a716-446655440000',
+      validation_uuid: '660e8400-e29b-41d4-a716-446655440000',
+      key_length: 'ec384',
+    }, client);
+
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/certificates/add', expect.objectContaining({
+      certificate: expect.objectContaining({
+        keyLength: 'key_ec384',
+      }),
+    }));
+  });
+
+  it('passes RSA key lengths unchanged', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ uuid: 'cert-uuid' }),
+    });
+
+    await handleAcmeTool('opnsense_acme_create_cert', {
+      name: 'test.example.com',
+      alt_names: 'test.example.com',
+      account_uuid: '550e8400-e29b-41d4-a716-446655440000',
+      validation_uuid: '660e8400-e29b-41d4-a716-446655440000',
+      key_length: '4096',
+    }, client);
+
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/certificates/add', expect.objectContaining({
+      certificate: expect.objectContaining({
+        keyLength: '4096',
       }),
     }));
   });
@@ -224,6 +313,51 @@ describe('handleAcmeTool', () => {
 
     expect(result.content[0].type).toBe('text');
     expect(client.post).toHaveBeenCalledWith('/acmeclient/accounts/del/550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('registers an ACME account', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ response: 'OK' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_register_account', {
+      uuid: '550e8400-e29b-41d4-a716-446655440000',
+    }, client);
+
+    expect(result.content[0].text).toContain('OK');
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/accounts/register/550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('gets ACME settings when no params provided', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({ acmeclient: { settings: { enabled: '1', environment: 'prod' } } }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_settings', {}, client);
+    expect(result.content[0].text).toContain('prod');
+    expect(client.get).toHaveBeenCalledWith('/acmeclient/settings/get');
+  });
+
+  it('updates ACME settings with acmeclient wrapper (#26)', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ result: 'saved' }),
+    });
+
+    const result = await handleAcmeTool('opnsense_acme_settings', {
+      enabled: '1',
+      environment: 'prod',
+    }, client);
+
+    expect(result.content[0].text).toContain('saved');
+    // CRITICAL: must use acmeclient wrapper (#26)
+    expect(client.post).toHaveBeenCalledWith('/acmeclient/settings/set', {
+      acmeclient: {
+        settings: {
+          enabled: '1',
+          environment: 'prod',
+        },
+      },
+    });
   });
 
   it('returns error for unknown tool', async () => {


### PR DESCRIPTION
## Summary

- Fix keyLength mapping: `ec256` → `key_ec256`, `ec384` → `key_ec384` (#23)
- Fix ACME challenge tool: add provider-specific credential fields (dns_cf_token, etc.) (#24)
- Fix validation update: use `/update/` endpoint instead of `/set/` (#25)
- Fix settings API: use correct `acmeclient` wrapper key (#26)
- Add `opnsense_acme_settings` tool for service management (#27)
- Add `opnsense_acme_register_account` tool (#28)
- Add `opnsense_acme_update_challenge` tool (#25)

Closes #23, Closes #24, Closes #25, Closes #26, Closes #27, Closes #28

## Test plan

- [x] All 56 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [ ] Verify keyLength mapping sends `key_ec256` via live API
- [ ] Verify challenge update uses `/update/` endpoint
- [ ] Verify settings wrapper `acmeclient` persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)