### PR TITLE
feat: add web GUI certificate assignment tool (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.13.10
+
+- Add `opnsense_sys_set_webgui_cert` tool: assign SSL cert to web GUI via config backup/restore (#29)
+- Add `opnsense_sys_list_certs` tool: list certificates in trust store with refids (#29)
+- Add `getRaw()` method to HTTP client for XML responses (#29)
+- Add 12 system tool tests (new test file)
+- Total: 62 tools, 68 tests
+
 ## v2026.03.13.9
 
 - Fix keyLength mapping: `ec256` → `key_ec256`, `ec384` → `key_ec384` for OPNsense API (#23)

--- a/src/client/opnsense-client.ts
+++ b/src/client/opnsense-client.ts
@@ -34,6 +34,18 @@ export class OPNsenseClient {
     }
   }
 
+  async getRaw(path: string): Promise<string> {
+    try {
+      const response = await this.http.get<string>(path, {
+        responseType: "text",
+        headers: { Accept: "application/xml" },
+      });
+      return response.data;
+    } catch (error: unknown) {
+      throw extractError(error, `GET ${path} (raw)`);
+    }
+  }
+
   async post<T>(path: string, data?: unknown): Promise<T> {
     try {
       const response = await this.http.post<T>(path, data ?? {}, {

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -18,6 +18,13 @@ const ServiceControlSchema = z.object({
   action: ServiceActionSchema,
 });
 
+const SetWebguiCertSchema = z.object({
+  cert_refid: z.string().min(1, "Certificate refid is required"),
+  confirm: z.literal(true, {
+    errorMap: () => ({ message: "confirm must be true to proceed — this will restart the web GUI" }),
+  }),
+});
+
 // ---------------------------------------------------------------------------
 // Tool definitions (for ListTools)
 // ---------------------------------------------------------------------------
@@ -52,6 +59,31 @@ export const systemToolDefinitions = [
         },
       },
       required: ["backup_data", "confirm"],
+    },
+  },
+  {
+    name: "opnsense_sys_list_certs",
+    description: "List all certificates in the OPNsense trust store with their refids, descriptions, and validity dates",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_sys_set_webgui_cert",
+    description:
+      "Assign an SSL certificate to the OPNsense web GUI. Downloads config, updates ssl-certref, restores config, and restarts the web GUI. Use opnsense_sys_list_certs to find available cert_refid values. Requires explicit confirmation as it restarts the web GUI (brief connectivity loss).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cert_refid: {
+          type: "string",
+          description: "Certificate refid from opnsense_sys_list_certs (e.g. '69b4367c83731')",
+        },
+        confirm: {
+          type: "boolean",
+          description: "Must be true to confirm — this will restart the web GUI",
+          enum: [true],
+        },
+      },
+      required: ["cert_refid", "confirm"],
     },
   },
   {
@@ -107,6 +139,79 @@ export async function handleSystemTool(
           backupdata: parsed.backup_data,
         });
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_sys_list_certs": {
+        const result = await client.get("/trust/cert/search");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_sys_set_webgui_cert": {
+        const parsed = SetWebguiCertSchema.parse(args);
+
+        // Step 1: Verify the certificate exists in the trust store
+        const certs = await client.get<{ rows: Array<{ refid: string; descr: string }> }>("/trust/cert/search");
+        const cert = certs.rows.find((c) => c.refid === parsed.cert_refid);
+        if (!cert) {
+          const available = certs.rows.map((c) => `${c.refid} (${c.descr})`).join(", ");
+          return {
+            content: [{
+              type: "text",
+              text: `Certificate with refid '${parsed.cert_refid}' not found. Available: ${available}`,
+            }],
+          };
+        }
+
+        // Step 2: Download current config backup
+        const configXml = await client.getRaw("/core/backup/download/this");
+        if (!configXml.includes("<opnsense>")) {
+          return {
+            content: [{ type: "text", text: "Failed to download configuration backup" }],
+          };
+        }
+
+        // Step 3: Replace ssl-certref in the config
+        const currentMatch = configXml.match(/<ssl-certref>(.*?)<\/ssl-certref>/);
+        if (!currentMatch) {
+          return {
+            content: [{ type: "text", text: "Could not find ssl-certref in configuration" }],
+          };
+        }
+
+        const currentRefid = currentMatch[1];
+        if (currentRefid === parsed.cert_refid) {
+          return {
+            content: [{ type: "text", text: `Web GUI already uses certificate '${cert.descr}' (${parsed.cert_refid})` }],
+          };
+        }
+
+        const modifiedXml = configXml.replace(
+          `<ssl-certref>${currentRefid}</ssl-certref>`,
+          `<ssl-certref>${parsed.cert_refid}</ssl-certref>`,
+        );
+
+        // Step 4: Restore the modified config
+        const restoreResult = await client.post<{ status?: string }>("/core/backup/restore", {
+          backupdata: modifiedXml,
+        });
+
+        // Step 5: Restart the web GUI service to apply
+        await client.post("/core/service/restart/webgui");
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              status: "ok",
+              message: `Web GUI certificate changed from '${currentRefid}' to '${parsed.cert_refid}' (${cert.descr})`,
+              previous_certref: currentRefid,
+              new_certref: parsed.cert_refid,
+              certificate_name: cert.descr,
+              restore_status: restoreResult.status ?? "completed",
+              note: "Web GUI is restarting — expect brief connectivity loss",
+            }, null, 2),
+          }],
+        };
       }
 
       case "opnsense_svc_list": {

--- a/tests/tools/system.test.ts
+++ b/tests/tools/system.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest';
+import { systemToolDefinitions, handleSystemTool } from '../../src/tools/system.js';
+import type { OPNsenseClient } from '../../src/client/opnsense-client.js';
+
+function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
+  return {
+    get: vi.fn().mockResolvedValue({ rows: [] }),
+    post: vi.fn().mockResolvedValue({ status: 'ok' }),
+    delete: vi.fn().mockResolvedValue({ status: 'ok' }),
+    getRaw: vi.fn().mockResolvedValue(''),
+    ...overrides,
+  } as unknown as OPNsenseClient;
+}
+
+describe('System Tool Definitions', () => {
+  it('exports 7 tool definitions', () => {
+    expect(systemToolDefinitions).toHaveLength(7);
+  });
+
+  it('all tools have opnsense_ prefix', () => {
+    for (const tool of systemToolDefinitions) {
+      expect(tool.name).toMatch(/^opnsense_/);
+    }
+  });
+
+  it('all tools have descriptions', () => {
+    for (const tool of systemToolDefinitions) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description.length).toBeGreaterThan(10);
+    }
+  });
+});
+
+describe('handleSystemTool', () => {
+  it('gets system info', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({ hostname: 'bifrost', uptime: '5d' }),
+    });
+
+    const result = await handleSystemTool('opnsense_sys_info', {}, client);
+    expect(result.content[0].text).toContain('bifrost');
+    expect(client.get).toHaveBeenCalledWith('/core/system/status');
+  });
+
+  it('lists certificates from trust store', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({
+        rows: [
+          { refid: '674eb8952f75f', descr: 'Self-signed cert' },
+          { refid: '69b4367c83731', descr: 'bifrost.itunified.io (ACME)' },
+        ],
+      }),
+    });
+
+    const result = await handleSystemTool('opnsense_sys_list_certs', {}, client);
+    expect(result.content[0].text).toContain('674eb8952f75f');
+    expect(result.content[0].text).toContain('69b4367c83731');
+    expect(client.get).toHaveBeenCalledWith('/trust/cert/search');
+  });
+
+  it('sets webgui cert successfully', async () => {
+    const configXml = '<opnsense><system><webgui><ssl-certref>old-ref</ssl-certref></webgui></system></opnsense>';
+    const getRaw = vi.fn().mockResolvedValue(configXml);
+    const get = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [
+          { refid: 'old-ref', descr: 'Old cert' },
+          { refid: 'new-ref', descr: 'New ACME cert' },
+        ],
+      });
+    const post = vi.fn().mockResolvedValue({ status: 'ok' });
+
+    const client = mockClient({ get, getRaw, post });
+
+    const result = await handleSystemTool('opnsense_sys_set_webgui_cert', {
+      cert_refid: 'new-ref',
+      confirm: true,
+    }, client);
+
+    expect(result.content[0].text).toContain('new-ref');
+    expect(result.content[0].text).toContain('New ACME cert');
+
+    // Verify backup was downloaded
+    expect(getRaw).toHaveBeenCalledWith('/core/backup/download/this');
+
+    // Verify modified config was restored with new refid
+    expect(post).toHaveBeenCalledWith('/core/backup/restore', {
+      backupdata: expect.stringContaining('<ssl-certref>new-ref</ssl-certref>'),
+    });
+
+    // Verify webgui restart was triggered
+    expect(post).toHaveBeenCalledWith('/core/service/restart/webgui');
+  });
+
+  it('rejects webgui cert if refid not found', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({
+        rows: [{ refid: 'existing-ref', descr: 'Existing cert' }],
+      }),
+    });
+
+    const result = await handleSystemTool('opnsense_sys_set_webgui_cert', {
+      cert_refid: 'nonexistent-ref',
+      confirm: true,
+    }, client);
+
+    expect(result.content[0].text).toContain('not found');
+    expect(result.content[0].text).toContain('existing-ref');
+  });
+
+  it('skips if webgui already uses the requested cert', async () => {
+    const configXml = '<opnsense><system><webgui><ssl-certref>same-ref</ssl-certref></webgui></system></opnsense>';
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({
+        rows: [{ refid: 'same-ref', descr: 'Current cert' }],
+      }),
+      getRaw: vi.fn().mockResolvedValue(configXml),
+    });
+
+    const result = await handleSystemTool('opnsense_sys_set_webgui_cert', {
+      cert_refid: 'same-ref',
+      confirm: true,
+    }, client);
+
+    expect(result.content[0].text).toContain('already uses');
+  });
+
+  it('requires confirm=true for webgui cert change', async () => {
+    const client = mockClient();
+
+    const result = await handleSystemTool('opnsense_sys_set_webgui_cert', {
+      cert_refid: 'new-ref',
+      confirm: false,
+    }, client);
+
+    expect(result.content[0].text).toContain('Error');
+  });
+
+  it('lists services', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({ rows: [{ name: 'unbound', running: true }] }),
+    });
+
+    const result = await handleSystemTool('opnsense_svc_list', {}, client);
+    expect(result.content[0].text).toContain('unbound');
+    expect(client.get).toHaveBeenCalledWith('/core/service/search');
+  });
+
+  it('controls a service', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ response: 'OK' }),
+    });
+
+    const result = await handleSystemTool('opnsense_svc_control', {
+      service_name: 'unbound',
+      action: 'restart',
+    }, client);
+
+    expect(result.content[0].text).toContain('OK');
+    expect(client.post).toHaveBeenCalledWith('/core/service/restart/unbound');
+  });
+
+  it('returns error for unknown tool', async () => {
+    const client = mockClient();
+    const result = await handleSystemTool('opnsense_sys_nonexistent', {}, client);
+    expect(result.content[0].text).toContain('Unknown');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `opnsense_sys_set_webgui_cert` tool: assign SSL cert to web GUI via config backup/restore
- Add `opnsense_sys_list_certs` tool: list certificates in OPNsense trust store
- Add `getRaw()` method to HTTP client for XML config download
- 12 new system tool unit tests

Approach: downloads config XML → modifies `ssl-certref` → restores config → restarts web GUI.
No dedicated API exists for this in OPNsense, so config backup/restore is the only API-based method.

Closes #29

## Test plan

- [x] All 68 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [ ] Verify `opnsense_sys_list_certs` returns cert list
- [ ] Verify `opnsense_sys_set_webgui_cert` changes the cert and restarts web GUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)