### PR TITLE
fix: remove broken sys_set_webgui_cert and sys_restore tools (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.13.11
+
+- Remove broken `opnsense_sys_set_webgui_cert` tool — OPNsense has no config restore/import API (#33)
+- Remove broken `opnsense_sys_restore` tool — `/core/backup/restore` endpoint does not exist (#33)
+- Keep `opnsense_sys_list_certs` tool (works correctly)
+- Keep `getRaw()` client method (useful for future XML responses)
+- Total: 60 tools, 65 tests
+
 ## v2026.03.13.10
 
 - Add `opnsense_sys_set_webgui_cert` tool: assign SSL cert to web GUI via config backup/restore (#29)

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -6,23 +6,9 @@ import { ServiceActionSchema } from "../utils/validation.js";
 // Zod schemas for input validation
 // ---------------------------------------------------------------------------
 
-const RestoreSchema = z.object({
-  backup_data: z.string().min(1, "Backup data is required"),
-  confirm: z.literal(true, {
-    errorMap: () => ({ message: "confirm must be true to proceed with restore" }),
-  }),
-});
-
 const ServiceControlSchema = z.object({
   service_name: z.string().min(1, "Service name is required"),
   action: ServiceActionSchema,
-});
-
-const SetWebguiCertSchema = z.object({
-  cert_refid: z.string().min(1, "Certificate refid is required"),
-  confirm: z.literal(true, {
-    errorMap: () => ({ message: "confirm must be true to proceed — this will restart the web GUI" }),
-  }),
 });
 
 // ---------------------------------------------------------------------------
@@ -42,49 +28,10 @@ export const systemToolDefinitions = [
     inputSchema: { type: "object" as const, properties: {} },
   },
   {
-    name: "opnsense_sys_restore",
-    description:
-      "Restore a configuration backup. DESTRUCTIVE: replaces the current configuration. Requires explicit confirmation.",
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        backup_data: {
-          type: "string",
-          description: "The backup XML data to restore",
-        },
-        confirm: {
-          type: "boolean",
-          description: "Must be true to confirm the restore operation",
-          enum: [true],
-        },
-      },
-      required: ["backup_data", "confirm"],
-    },
-  },
-  {
     name: "opnsense_sys_list_certs",
-    description: "List all certificates in the OPNsense trust store with their refids, descriptions, and validity dates",
-    inputSchema: { type: "object" as const, properties: {} },
-  },
-  {
-    name: "opnsense_sys_set_webgui_cert",
     description:
-      "Assign an SSL certificate to the OPNsense web GUI. Downloads config, updates ssl-certref, restores config, and restarts the web GUI. Use opnsense_sys_list_certs to find available cert_refid values. Requires explicit confirmation as it restarts the web GUI (brief connectivity loss).",
-    inputSchema: {
-      type: "object" as const,
-      properties: {
-        cert_refid: {
-          type: "string",
-          description: "Certificate refid from opnsense_sys_list_certs (e.g. '69b4367c83731')",
-        },
-        confirm: {
-          type: "boolean",
-          description: "Must be true to confirm — this will restart the web GUI",
-          enum: [true],
-        },
-      },
-      required: ["cert_refid", "confirm"],
-    },
+      "List all certificates in the OPNsense trust store with their refids, descriptions, and validity dates",
+    inputSchema: { type: "object" as const, properties: {} },
   },
   {
     name: "opnsense_svc_list",
@@ -133,85 +80,9 @@ export async function handleSystemTool(
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
-      case "opnsense_sys_restore": {
-        const parsed = RestoreSchema.parse(args);
-        const result = await client.post("/core/backup/restore", {
-          backupdata: parsed.backup_data,
-        });
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-      }
-
       case "opnsense_sys_list_certs": {
         const result = await client.get("/trust/cert/search");
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-      }
-
-      case "opnsense_sys_set_webgui_cert": {
-        const parsed = SetWebguiCertSchema.parse(args);
-
-        // Step 1: Verify the certificate exists in the trust store
-        const certs = await client.get<{ rows: Array<{ refid: string; descr: string }> }>("/trust/cert/search");
-        const cert = certs.rows.find((c) => c.refid === parsed.cert_refid);
-        if (!cert) {
-          const available = certs.rows.map((c) => `${c.refid} (${c.descr})`).join(", ");
-          return {
-            content: [{
-              type: "text",
-              text: `Certificate with refid '${parsed.cert_refid}' not found. Available: ${available}`,
-            }],
-          };
-        }
-
-        // Step 2: Download current config backup
-        const configXml = await client.getRaw("/core/backup/download/this");
-        if (!configXml.includes("<opnsense>")) {
-          return {
-            content: [{ type: "text", text: "Failed to download configuration backup" }],
-          };
-        }
-
-        // Step 3: Replace ssl-certref in the config
-        const currentMatch = configXml.match(/<ssl-certref>(.*?)<\/ssl-certref>/);
-        if (!currentMatch) {
-          return {
-            content: [{ type: "text", text: "Could not find ssl-certref in configuration" }],
-          };
-        }
-
-        const currentRefid = currentMatch[1];
-        if (currentRefid === parsed.cert_refid) {
-          return {
-            content: [{ type: "text", text: `Web GUI already uses certificate '${cert.descr}' (${parsed.cert_refid})` }],
-          };
-        }
-
-        const modifiedXml = configXml.replace(
-          `<ssl-certref>${currentRefid}</ssl-certref>`,
-          `<ssl-certref>${parsed.cert_refid}</ssl-certref>`,
-        );
-
-        // Step 4: Restore the modified config
-        const restoreResult = await client.post<{ status?: string }>("/core/backup/restore", {
-          backupdata: modifiedXml,
-        });
-
-        // Step 5: Restart the web GUI service to apply
-        await client.post("/core/service/restart/webgui");
-
-        return {
-          content: [{
-            type: "text",
-            text: JSON.stringify({
-              status: "ok",
-              message: `Web GUI certificate changed from '${currentRefid}' to '${parsed.cert_refid}' (${cert.descr})`,
-              previous_certref: currentRefid,
-              new_certref: parsed.cert_refid,
-              certificate_name: cert.descr,
-              restore_status: restoreResult.status ?? "completed",
-              note: "Web GUI is restarting — expect brief connectivity loss",
-            }, null, 2),
-          }],
-        };
       }
 
       case "opnsense_svc_list": {

--- a/tests/tools/system.test.ts
+++ b/tests/tools/system.test.ts
@@ -13,8 +13,8 @@ function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
 }
 
 describe('System Tool Definitions', () => {
-  it('exports 7 tool definitions', () => {
-    expect(systemToolDefinitions).toHaveLength(7);
+  it('exports 5 tool definitions', () => {
+    expect(systemToolDefinitions).toHaveLength(5);
   });
 
   it('all tools have opnsense_ prefix', () => {
@@ -42,6 +42,16 @@ describe('handleSystemTool', () => {
     expect(client.get).toHaveBeenCalledWith('/core/system/status');
   });
 
+  it('creates a backup', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ status: 'ok' }),
+    });
+
+    const result = await handleSystemTool('opnsense_sys_backup', {}, client);
+    expect(result.content[0].text).toContain('ok');
+    expect(client.post).toHaveBeenCalledWith('/core/backup/backup');
+  });
+
   it('lists certificates from trust store', async () => {
     const client = mockClient({
       get: vi.fn().mockResolvedValue({
@@ -56,84 +66,6 @@ describe('handleSystemTool', () => {
     expect(result.content[0].text).toContain('674eb8952f75f');
     expect(result.content[0].text).toContain('69b4367c83731');
     expect(client.get).toHaveBeenCalledWith('/trust/cert/search');
-  });
-
-  it('sets webgui cert successfully', async () => {
-    const configXml = '<opnsense><system><webgui><ssl-certref>old-ref</ssl-certref></webgui></system></opnsense>';
-    const getRaw = vi.fn().mockResolvedValue(configXml);
-    const get = vi.fn()
-      .mockResolvedValueOnce({
-        rows: [
-          { refid: 'old-ref', descr: 'Old cert' },
-          { refid: 'new-ref', descr: 'New ACME cert' },
-        ],
-      });
-    const post = vi.fn().mockResolvedValue({ status: 'ok' });
-
-    const client = mockClient({ get, getRaw, post });
-
-    const result = await handleSystemTool('opnsense_sys_set_webgui_cert', {
-      cert_refid: 'new-ref',
-      confirm: true,
-    }, client);
-
-    expect(result.content[0].text).toContain('new-ref');
-    expect(result.content[0].text).toContain('New ACME cert');
-
-    // Verify backup was downloaded
-    expect(getRaw).toHaveBeenCalledWith('/core/backup/download/this');
-
-    // Verify modified config was restored with new refid
-    expect(post).toHaveBeenCalledWith('/core/backup/restore', {
-      backupdata: expect.stringContaining('<ssl-certref>new-ref</ssl-certref>'),
-    });
-
-    // Verify webgui restart was triggered
-    expect(post).toHaveBeenCalledWith('/core/service/restart/webgui');
-  });
-
-  it('rejects webgui cert if refid not found', async () => {
-    const client = mockClient({
-      get: vi.fn().mockResolvedValue({
-        rows: [{ refid: 'existing-ref', descr: 'Existing cert' }],
-      }),
-    });
-
-    const result = await handleSystemTool('opnsense_sys_set_webgui_cert', {
-      cert_refid: 'nonexistent-ref',
-      confirm: true,
-    }, client);
-
-    expect(result.content[0].text).toContain('not found');
-    expect(result.content[0].text).toContain('existing-ref');
-  });
-
-  it('skips if webgui already uses the requested cert', async () => {
-    const configXml = '<opnsense><system><webgui><ssl-certref>same-ref</ssl-certref></webgui></system></opnsense>';
-    const client = mockClient({
-      get: vi.fn().mockResolvedValue({
-        rows: [{ refid: 'same-ref', descr: 'Current cert' }],
-      }),
-      getRaw: vi.fn().mockResolvedValue(configXml),
-    });
-
-    const result = await handleSystemTool('opnsense_sys_set_webgui_cert', {
-      cert_refid: 'same-ref',
-      confirm: true,
-    }, client);
-
-    expect(result.content[0].text).toContain('already uses');
-  });
-
-  it('requires confirm=true for webgui cert change', async () => {
-    const client = mockClient();
-
-    const result = await handleSystemTool('opnsense_sys_set_webgui_cert', {
-      cert_refid: 'new-ref',
-      confirm: false,
-    }, client);
-
-    expect(result.content[0].text).toContain('Error');
   });
 
   it('lists services', async () => {


### PR DESCRIPTION
## Summary

- Remove `opnsense_sys_set_webgui_cert` — OPNsense has no config restore/import API
- Remove `opnsense_sys_restore` — `/core/backup/restore` endpoint does not exist
- Keep `opnsense_sys_list_certs` (works correctly)

Verified on OPNsense 24.7 and latest master: `ssl-certref` is only modifiable via legacy `system_advanced_admin.php` form POST (session auth + CSRF).

Closes #33

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 65 tests pass
- [x] Tool definitions reduced from 62 to 60

🤖 Generated with [Claude Code](https://claude.com/claude-code)