### PR TITLE
feat: add 5 Claude Code skills for MCP tool orchestration

### DIFF
--- a/.claude/skills/opnsense-acme-renew/SKILL.md
+++ b/.claude/skills/opnsense-acme-renew/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: opnsense-acme-renew
+description: Check ACME certificate expiry and renew if needed — lists all certs, shows days remaining, triggers renewal
+disable-model-invocation: true
+---
+
+# OPNsense ACME Certificate Renewal (/renew-cert)
+
+Check ACME certificate status and renew certificates approaching expiry.
+
+## Workflow
+
+### Step 1: Gather Certificate Data (run in parallel)
+1. `opnsense_acme_list_certs` — all ACME certificates with status and last update
+2. `opnsense_sys_list_certs` — all certificates in the trust store with validity dates
+3. `opnsense_acme_settings` — current ACME service settings (enabled, auto-renewal)
+
+### Step 2: Analyze Expiry
+
+For each ACME certificate:
+1. Match it to its trust store entry by name/description
+2. Calculate days remaining from `valid_to` timestamp
+3. Categorize:
+   - **Expired**: valid_to < now
+   - **Critical**: < 7 days remaining
+   - **Warning**: < 30 days remaining
+   - **OK**: >= 30 days remaining
+
+### Step 3: Renew if Needed
+
+For certificates that are Expired, Critical, or Warning:
+1. Ask the user for confirmation: "Certificate {name} expires in {days} days. Renew now?"
+2. If confirmed: `opnsense_acme_renew_cert` with the certificate UUID
+3. `opnsense_acme_apply` — apply changes
+4. Wait a moment, then re-check with `opnsense_acme_list_certs` to verify renewal succeeded
+
+### Step 4: Report
+
+```
+## ACME Certificate Status
+
+### Service Settings
+- ACME Enabled: {yes/no}
+- Auto-Renewal: {enabled/disabled}
+- Environment: {production/staging}
+
+### Certificates
+| Name | Status | Expires | Days Left | Last Renewed |
+|------|--------|---------|-----------|-------------|
+| {name} | {OK/Warning/Critical/Expired} | {date} | {days} | {date} |
+
+### Actions Taken
+- {cert name}: Renewed successfully / Renewal failed: {error} / No action needed
+```
+
+## Important
+- ALWAYS ask for confirmation before renewing — renewal triggers a new ACME challenge
+- If auto-renewal is disabled, suggest enabling it: `opnsense_acme_settings` with `autoRenewal: "1"`
+- Let's Encrypt certs are valid for 90 days; renewal typically happens at 60 days
+- The ACME cert renewal does NOT automatically update the web GUI SSL certificate — that requires a manual GUI step (System > Settings > Administration)
+- If renewal fails, check: ACME account registered, DNS challenge configured, Cloudflare credentials valid

--- a/.claude/skills/opnsense-diagnostics/SKILL.md
+++ b/.claude/skills/opnsense-diagnostics/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: opnsense-diagnostics
+description: Diagnose network connectivity issues using OPNsense firewall tools — ping, traceroute, DNS lookup, ARP, firewall states and logs
+---
+
+# OPNsense Network Diagnostics
+
+Run a structured diagnostic workflow when the user reports connectivity issues, network problems, or asks to troubleshoot why a host can't be reached.
+
+## Keywords
+diagnose, connectivity, network issue, can't reach, troubleshoot, ping, traceroute, unreachable, timeout, blocked
+
+## When to Use
+- User says "diagnose connectivity to X" or "why can't I reach X"
+- User reports a network issue or timeout
+- User asks to troubleshoot a connection problem
+- User asks "is X reachable from the firewall"
+
+## Workflow
+
+Execute these steps in order. Run independent checks in parallel where possible.
+
+### Step 1: Identify the Target
+Extract the target hostname or IP from the user's request. If ambiguous, ask for clarification.
+
+### Step 2: Basic Connectivity (run in parallel)
+1. **Ping** — `opnsense_diag_ping` with the target address (count: 3)
+2. **DNS Lookup** — `opnsense_diag_dns_lookup` with the hostname (skip if target is an IP)
+3. **Traceroute** — `opnsense_diag_traceroute` to the target
+
+### Step 3: Local Network State (run in parallel)
+1. **ARP Table** — `opnsense_diag_arp_table` — check if target has an ARP entry (local network)
+2. **Firewall States** — `opnsense_diag_fw_states` — check for active connections to/from the target
+3. **Routing Table** — `opnsense_diag_routes` — verify a route exists for the target
+
+### Step 4: Firewall Logs
+1. **Recent Logs** — `opnsense_diag_fw_logs` with limit 100 — filter for entries matching the target IP
+
+### Step 5: Report
+
+Present findings in this format:
+
+```
+## Diagnostic Report: {target}
+
+### Connectivity
+- Ping: {PASS/FAIL} — {latency or error}
+- DNS: {PASS/FAIL/SKIP} — {resolved IP or error}
+- Traceroute: {hops summary}
+
+### Network State
+- ARP Entry: {found/not found}
+- Active FW States: {count matching target}
+- Route: {matching route or "no route"}
+
+### Firewall Logs
+- Recent blocks matching target: {count}
+- {details if blocks found}
+
+### Assessment
+{One paragraph summary: what's working, what's failing, likely root cause}
+
+### Recommended Actions
+- {Actionable next steps}
+```
+
+## Error Handling
+- If a diagnostic tool returns an error (e.g., endpoint not found), note it in the report as "Unavailable" and continue with remaining checks
+- Never skip the report — partial results are still valuable
+- If the target is unreachable AND firewall blocks are found, highlight this as the likely cause

--- a/.claude/skills/opnsense-dns-management/SKILL.md
+++ b/.claude/skills/opnsense-dns-management/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: opnsense-dns-management
+description: Manage OPNsense DNS host overrides — add, list, delete records and verify resolution
+---
+
+# OPNsense DNS Management
+
+Orchestrate DNS record management on OPNsense Unbound with verification.
+
+## Keywords
+DNS, record, hostname, override, add DNS, delete DNS, manage DNS, host override, A record, CNAME
+
+## When to Use
+- User asks to add, modify, or delete a DNS record
+- User asks to set up a hostname on the firewall
+- User asks to list current DNS overrides
+- User asks to block or unblock a domain
+
+## Workflow
+
+### Adding a DNS Record
+
+#### Step 1: Gather Parameters
+Required: hostname, domain, target IP (or CNAME target)
+Optional: record type (A, AAAA, CNAME — default A), description
+
+If the user says "point myserver.home.lab to 10.10.0.100", extract:
+- hostname: `myserver`
+- domain: `home.lab`
+- server: `10.10.0.100`
+- type: `A`
+
+#### Step 2: Check Existing Records
+Run `opnsense_dns_list_overrides` to check for conflicts:
+- Same hostname+domain already exists — warn user, ask if they want to update (delete old + add new)
+- Different hostname pointing to same IP — inform user (not necessarily a conflict)
+
+#### Step 3: Create the Record
+Run `opnsense_dns_add_override` with the gathered parameters.
+
+#### Step 4: Apply Changes
+Run `opnsense_dns_apply` to reconfigure Unbound. This is MANDATORY — changes don't take effect without it.
+
+#### Step 5: Verify
+Run `opnsense_diag_dns_lookup` with the full hostname to confirm resolution.
+If the lookup tool is unavailable, note that verification should be done manually.
+
+#### Step 6: Report
+```
+DNS Record Created:
+  {hostname}.{domain} -> {server} ({type})
+  Applied: Yes
+  Verified: {Yes — resolves to {IP} / No — lookup failed / Manual verification needed}
+```
+
+### Deleting a DNS Record
+
+#### Step 1: Find the Record
+Run `opnsense_dns_list_overrides` and find the matching record by hostname/domain.
+If not found, inform the user.
+
+#### Step 2: Confirm with User
+Show the record details and ask for confirmation before deleting.
+
+#### Step 3: Delete
+Run `opnsense_dns_delete_override` with the UUID.
+
+#### Step 4: Apply
+Run `opnsense_dns_apply`.
+
+#### Step 5: Report
+```
+DNS Record Deleted:
+  {hostname}.{domain} (UUID: {uuid})
+  Applied: Yes
+```
+
+### Listing DNS Records
+Run `opnsense_dns_list_overrides` and format as a table:
+```
+| Hostname | Domain | Target | Type | UUID |
+|----------|--------|--------|------|------|
+```
+
+### Domain Blocking/Unblocking
+- Block: `opnsense_dns_block_domain` then `opnsense_dns_apply`
+- Unblock: find UUID via `opnsense_dns_list_blocklist` then `opnsense_dns_unblock_domain` then `opnsense_dns_apply`
+
+## Important
+- ALWAYS run `opnsense_dns_apply` after any changes — without it, changes are staged but not active
+- Deleting a record requires the UUID — always list first to find it
+- Ask for confirmation before deleting records

--- a/.claude/skills/opnsense-firewall-audit/SKILL.md
+++ b/.claude/skills/opnsense-firewall-audit/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: opnsense-firewall-audit
+description: Audit OPNsense firewall rules for security issues — overly permissive rules, disabled rules, unused aliases
+---
+
+# OPNsense Firewall Audit
+
+Perform a security audit of the OPNsense firewall configuration.
+
+## Keywords
+audit, firewall, review rules, security check, firewall review, permissive, rules audit, security audit
+
+## When to Use
+- User asks to audit or review firewall rules
+- User asks for a security check of the firewall
+- User wants to know if any rules are too permissive
+- User asks about firewall configuration quality
+
+## Workflow
+
+### Step 1: Gather Firewall Configuration (run in parallel)
+1. `opnsense_fw_list_rules` — all filter rules
+2. `opnsense_fw_list_aliases` — all aliases (host groups, networks, ports)
+
+### Step 2: Analyze Rules
+
+Check for these security concerns:
+
+**Critical**
+- Rules with source=any AND destination=any AND action=pass (allow-all)
+- Rules with protocol=any AND no port restrictions
+- Pass rules on WAN interface with no source restrictions
+
+**Warning**
+- Disabled rules that were previously active (may indicate incomplete cleanup)
+- Rules with very broad source/destination (e.g., entire /8 networks)
+- Multiple rules that could be consolidated into alias-based rules
+
+**Info**
+- Total rule count per interface
+- Rules without descriptions (poor documentation)
+- Alias usage vs inline addresses
+
+### Step 3: Check Active State
+1. `opnsense_diag_fw_states` — active connection states (look for unexpected connections)
+2. `opnsense_diag_fw_logs` (limit: 200) — recent blocks (look for patterns)
+
+### Step 4: Report
+
+```
+## Firewall Audit Report
+
+### Summary
+- Total rules: {count}
+- Enabled: {count} | Disabled: {count}
+- Aliases: {count}
+- Active states: {count}
+
+### Critical Findings
+{List critical issues with rule details and remediation}
+
+### Warnings
+{List warnings with context}
+
+### Informational
+{List info items}
+
+### Blocked Traffic Patterns (Last 200 Entries)
+- Top blocked sources: {list}
+- Top blocked destinations: {list}
+- Top blocked ports: {list}
+
+### Recommendations
+1. {Prioritized action items}
+```
+
+## Important
+- This skill is READ-ONLY — it never modifies firewall rules
+- If the user asks to fix an issue found during audit, switch to manual rule management (not this skill)
+- Present findings objectively — let the user decide on remediation
+- An empty rule set is not necessarily a problem (OPNsense has implicit deny-all)

--- a/.claude/skills/opnsense-service-health/SKILL.md
+++ b/.claude/skills/opnsense-service-health/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: opnsense-service-health
+description: Dashboard-style health overview of the OPNsense firewall — system status, services, firmware, interfaces, DHCP
+disable-model-invocation: true
+---
+
+# OPNsense Health Check (/health)
+
+Produce a dashboard-style health overview of the OPNsense firewall.
+
+## Workflow
+
+### Step 1: Gather Data (run ALL in parallel)
+1. `opnsense_sys_info` — system status (CPU, memory, uptime, disk)
+2. `opnsense_svc_list` — all services and running status
+3. `opnsense_firmware_status` — firmware version and available updates
+4. `opnsense_firmware_info` — architecture and version details
+5. `opnsense_if_stats` — interface traffic statistics
+6. `opnsense_if_list` — interface name mappings
+7. `opnsense_dhcp_list_leases` — active DHCP leases
+
+### Step 2: Format Dashboard
+
+Present results in this format:
+
+```
+## OPNsense Health Dashboard
+
+### System
+- Status: {OK/Warning/Critical}
+- Uptime: {days/hours}
+- CPU: {usage}%
+- Memory: {used}/{total} ({percent}%)
+- Disk: {used}/{total} ({percent}%)
+
+### Firmware
+- Version: {version}
+- Architecture: {arch}
+- Updates Available: {yes/no — details if yes}
+
+### Services ({running}/{total} running)
+| Service | Status |
+|---------|--------|
+| {name} | {Running/Stopped} |
+(Highlight any stopped services that should be running)
+
+### Interfaces
+| Interface | Device | RX | TX | Errors |
+|-----------|--------|----|----|--------|
+| {name} | {device} | {bytes} | {bytes} | {count} |
+
+### DHCP
+- Active Leases: {count}
+- Online: {count} | Offline: {count}
+- Static Mappings: {count}
+```
+
+### Step 3: Highlight Issues
+At the end, add a section if any issues were detected:
+- Stopped services that are typically critical (unbound, configd, openssh)
+- Firmware updates available
+- Interface errors > 0
+- System status not OK
+- Disk usage > 80%
+
+## Important
+- This is a read-only health check — never modify configuration
+- Run all data gathering in parallel for speed
+- If a tool call fails, note it as "Unavailable" and continue with other checks
+- Keep output concise — this is meant to be scanned quickly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.13.15
+
+- Add 5 Claude Code skills for higher-level MCP tool orchestration (#41)
+  - `opnsense-diagnostics` — auto skill for network connectivity diagnostics
+  - `opnsense-dns-management` — auto skill for DNS record management with verification
+  - `opnsense-firewall-audit` — auto skill for firewall security audit
+  - `opnsense-service-health` — `/health` slash command for dashboard-style health overview
+  - `opnsense-acme-renew` — `/renew-cert` slash command for certificate status and renewal
+- Add Claude Code Skills section to README.md (#41)
+- Add skills conventions section to CLAUDE.md (#41)
+
 ## v2026.03.13.14
 
 - Switch license from MIT to AGPL-3.0 + commercial dual license (#39)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,46 @@ docs/
 - Bug fix commits must reference the issue: `fix: <description> (#<nr>)`
 - CHANGELOG entry required for every bug fix
 
+## Claude Code Skills
+
+Skills are higher-level workflow orchestrations that compose multiple MCP tools into structured task flows. They live in `.claude/skills/<name>/SKILL.md`.
+
+### Location Policy
+- **Skills MUST live in the MCP server repo** (this repo), NOT in private infrastructure repos
+- Skills are public and reusable by any user of the MCP server
+- See [ADR-0005](https://github.com/itunified-io/infrastructure) in the infrastructure repo for the architectural decision
+
+### Skill Structure
+```
+.claude/skills/
+  <skill-name>/
+    SKILL.md          # Skill definition with YAML frontmatter
+```
+
+### YAML Frontmatter
+```yaml
+---
+name: skill-name
+description: One-line description of what the skill does
+disable-model-invocation: true   # Optional: makes it user-only (slash command)
+---
+```
+
+### Skill Types
+- **Auto (Claude-invocable)**: Omit `disable-model-invocation` — Claude triggers automatically when relevant
+- **User-invocable (slash command)**: Set `disable-model-invocation: true` — user runs via `/command`
+
+### Naming Convention
+- Skill directory: `opnsense-<purpose>` (e.g., `opnsense-diagnostics`, `opnsense-service-health`)
+- Slash commands: short, memorable (e.g., `/health`, `/renew-cert`)
+
+### Skill Design Guidelines
+- Each skill MUST specify which MCP tools it uses
+- Workflow steps should maximize parallel tool calls for speed
+- Read-only skills (audits, health checks) MUST NOT modify configuration
+- Destructive actions MUST ask for user confirmation
+- Output should be structured (tables, sections) for quick scanning
+
 ## Language
 
 - All documentation, code comments, commit messages: **English only**

--- a/README.md
+++ b/README.md
@@ -159,6 +159,22 @@ Add to `.mcp.json` in your project root:
 | `opnsense_firmware_install` | Install an OPNsense plugin package |
 | `opnsense_firmware_remove` | Remove a plugin package (requires confirmation) |
 
+## Claude Code Skills
+
+This project includes Claude Code skills that orchestrate multiple MCP tools into higher-level workflows:
+
+| Skill | Type | Description |
+|-------|------|-------------|
+| `opnsense-diagnostics` | Auto | Network connectivity diagnostics (ping, traceroute, DNS, ARP, FW logs) |
+| `opnsense-dns-management` | Auto | DNS record management with verification (add, delete, apply, verify) |
+| `opnsense-firewall-audit` | Auto | Firewall rules security audit (permissive rules, disabled rules, patterns) |
+| `opnsense-service-health` | `/health` | Dashboard-style health overview (system, services, firmware, interfaces) |
+| `opnsense-acme-renew` | `/renew-cert` | ACME certificate status check and renewal |
+
+**Auto** skills are triggered automatically by Claude when relevant. **Slash command** skills are invoked explicitly by the user (e.g., `/health`).
+
+Skills are located in `.claude/skills/` and are auto-discovered when this repo is used as an MCP server.
+
 ## Known Limitations
 
 Some OPNsense operations are not available via the REST API and require manual GUI access:


### PR DESCRIPTION
## Summary
- Add 5 Claude Code skills that orchestrate multiple MCP tools into higher-level workflows
  - `opnsense-diagnostics` — auto skill for network connectivity diagnostics
  - `opnsense-dns-management` — auto skill for DNS record management with verification
  - `opnsense-firewall-audit` — auto skill for firewall security audit
  - `opnsense-service-health` — `/health` slash command for dashboard-style health overview
  - `opnsense-acme-renew` — `/renew-cert` slash command for certificate status and renewal
- Add skills conventions section to CLAUDE.md
- Add Claude Code Skills section to README.md
- Update CHANGELOG.md with v2026.03.13.15

Closes #41

## Test plan
- [ ] Verify `/health` slash command produces dashboard output
- [ ] Verify `/renew-cert` slash command shows cert status
- [ ] Verify "diagnose connectivity to 1.1.1.1" triggers diagnostics skill
- [ ] Verify "audit firewall rules" triggers firewall audit skill
- [ ] Verify "add DNS record" triggers DNS management skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)