### PR TITLE
feat: add backup list, download, revert tools + /backup skill (#43)

### DIFF
--- a/.claude/skills/opnsense-backup/SKILL.md
+++ b/.claude/skills/opnsense-backup/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: opnsense-backup
+description: OPNsense configuration backup management — list, download, and revert backups
+disable-model-invocation: true
+---
+
+# /backup — OPNsense Configuration Backup
+
+Manage OPNsense configuration backups: list available backups, download config XML, and revert to a previous configuration.
+
+## Workflow
+
+### Step 1: Gather System Context and Backup List
+
+Run these tools **in parallel**:
+
+- `opnsense_sys_info` — get current system version and hostname
+- `opnsense_sys_backup_list` — list all available configuration backups
+
+### Step 2: Present Backup Dashboard
+
+Format results as a structured dashboard:
+
+```
+## OPNsense Backup Dashboard
+
+### System
+- Hostname: ...
+- Version: ...
+
+### Available Backups (most recent first)
+| # | Timestamp | Description | User | Size |
+|---|-----------|-------------|------|------|
+| 1 | 2026-03-13 17:37 | /system_advanced_admin.php made changes | root@... | 75 KB |
+| 2 | ... | ... | ... | ... |
+
+Total: N backups available
+```
+
+### Step 3: Offer Actions
+
+Present available actions to the user:
+
+1. **Download current config** — downloads the running configuration as XML
+2. **Download specific backup** — downloads a specific backup by ID
+3. **Revert to backup** — reverts to a previous configuration (**DESTRUCTIVE** — requires confirmation)
+
+Wait for user to choose an action.
+
+### Step 4: Execute Action
+
+**If download (current or specific):**
+- Call `opnsense_sys_backup_download` (with `backup_id` if specific)
+- Present the XML content or note its size
+- Remind the user this is sensitive configuration data
+
+**If revert:**
+- **MUST ask for explicit user confirmation** before proceeding
+- Show the backup details (timestamp, description, user) being reverted to
+- Ask: "This will replace the running configuration. Are you sure? (yes/no)"
+- Only call `opnsense_sys_backup_revert` with the confirmed `backup_id` after user says "yes"
+- After revert, call `opnsense_sys_info` to verify the system is responsive
+
+## MCP Tools Used
+
+| Tool | Purpose | Destructive |
+|------|---------|-------------|
+| `opnsense_sys_info` | System context (version, hostname) | No |
+| `opnsense_sys_backup_list` | List available backups | No |
+| `opnsense_sys_backup_download` | Download config XML | No |
+| `opnsense_sys_backup_revert` | Revert to previous config | **Yes** |
+
+## Important Notes
+
+- **Revert is destructive** — always confirm with the user before executing
+- Config XML contains sensitive data (passwords, API keys) — warn the user
+- After revert, the OPNsense web UI may restart — expect a brief disconnection
+- Backups are stored on the OPNsense filesystem under `/conf/backup/`
+- There is no API to create a new backup or upload a config file — use the web GUI for those operations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.13.16
+
+- Replace broken `opnsense_sys_backup` with 3 new backup tools (#43):
+  - `opnsense_sys_backup_list` — list all configuration backups with timestamps
+  - `opnsense_sys_backup_download` — download config XML (current or specific backup)
+  - `opnsense_sys_backup_revert` — revert to a previous backup (destructive)
+- Add `/backup` slash command skill for configuration backup management (#43)
+- Fix: old `POST /core/backup/backup` endpoint no longer exists in OPNsense 24.7
+- Update tool count from 60 to 62, test count to 68
+
 ## v2026.03.13.15
 
 - Add 5 Claude Code skills for higher-level MCP tool orchestration (#41)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense REST API. Provides ~57 granular tools for DNS, Firewall, Diagnostics, Interfaces, DHCP, System, ACME, and Firmware management.
+Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense REST API. Provides ~62 granular tools for DNS, Firewall, Diagnostics, Interfaces, DHCP, System, ACME, and Firmware management.
 
 **No SSH. No shell execution. API-only.**
 
@@ -20,7 +20,7 @@ src/
     diagnostics.ts         # 8 Diagnostics tools
     interfaces.ts          # 3 Interface tools (read-only)
     dhcp.ts                # 5 DHCP tools (ISC + Kea dual support)
-    system.ts              # 5 System/Service tools
+    system.ts              # 7 System/Service/Backup tools
     acme.ts                # 11 ACME/Let's Encrypt tools
     firmware.ts            # 5 Firmware/Plugin management tools
   utils/

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense R
 
 ## Features
 
-60 tools across 8 domains:
+62 tools across 8 domains:
 
 - **DNS/Unbound** (12) — Host overrides, forwards, blocklist, cache management
 - **Firewall** (8) — Rules, aliases, NAT, apply changes
 - **Diagnostics** (8) — ARP, routes, ping, traceroute, DNS lookup, firewall states/logs
 - **Interfaces** (3) — List, configuration, statistics (read-only)
 - **DHCP** (5) — Leases, static mappings (ISC DHCPv4 + Kea dual support)
-- **System** (5) — Info, backup, certificate listing, service control
+- **System** (7) — Info, backup (list/download/revert), certificate listing, service control
 - **ACME/Let's Encrypt** (14) — Accounts, challenges, certificates, renewal, settings
 - **Firmware/Plugins** (5) — Version info, plugin management
 
@@ -57,7 +57,7 @@ Add to `.mcp.json` in your project root:
 | `OPNSENSE_VERIFY_SSL` | No | `true` | Set to `false` for self-signed certificates |
 | `OPNSENSE_TIMEOUT` | No | `30000` | Request timeout in milliseconds |
 
-## Available Tools (60)
+## Available Tools (62)
 
 ### DNS/Unbound (12 tools)
 
@@ -120,12 +120,14 @@ Add to `.mcp.json` in your project root:
 | `opnsense_dhcp_add_static` | Add a static DHCP mapping |
 | `opnsense_dhcp_delete_static` | Delete a static mapping by UUID |
 
-### System (5 tools)
+### System (7 tools)
 
 | Tool | Description |
 |------|-------------|
 | `opnsense_sys_info` | Get system status (hostname, versions, CPU, memory, uptime, disk) |
-| `opnsense_sys_backup` | Create a configuration backup |
+| `opnsense_sys_backup_list` | List all configuration backups with timestamps and descriptions |
+| `opnsense_sys_backup_download` | Download configuration backup as XML (current or specific) |
+| `opnsense_sys_backup_revert` | Revert to a previous configuration backup (**destructive**) |
 | `opnsense_sys_list_certs` | List all certificates in the trust store |
 | `opnsense_svc_list` | List all services and their running status |
 | `opnsense_svc_control` | Start, stop, or restart a service by name |
@@ -170,6 +172,7 @@ This project includes Claude Code skills that orchestrate multiple MCP tools int
 | `opnsense-firewall-audit` | Auto | Firewall rules security audit (permissive rules, disabled rules, patterns) |
 | `opnsense-service-health` | `/health` | Dashboard-style health overview (system, services, firmware, interfaces) |
 | `opnsense-acme-renew` | `/renew-cert` | ACME certificate status check and renewal |
+| `opnsense-backup` | `/backup` | Configuration backup management (list, download, revert) |
 
 **Auto** skills are triggered automatically by Claude when relevant. **Slash command** skills are invoked explicitly by the user (e.g., `/health`).
 
@@ -180,7 +183,7 @@ Skills are located in `.claude/skills/` and are auto-discovered when this repo i
 Some OPNsense operations are not available via the REST API and require manual GUI access:
 
 - **Web GUI SSL certificate assignment** — `ssl-certref` can only be changed via System > Settings > Administration in the web UI. See [docs/manual-operations.md](docs/manual-operations.md).
-- **Configuration restore/import** — OPNsense has no API to upload/import configuration XML. Only local backup revert is supported.
+- **Configuration upload/import** — OPNsense has no API to upload configuration XML files. Use `opnsense_sys_backup_revert` to revert to local backups, or upload via the web GUI.
 - **User/group management** — Not exposed via REST API.
 - **VPN configuration** — Limited API coverage; most settings require the web UI.
 

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -11,6 +11,17 @@ const ServiceControlSchema = z.object({
   action: ServiceActionSchema,
 });
 
+const BackupRevertSchema = z.object({
+  backup_id: z.string().min(1, "Backup ID is required (e.g. 'config-1773423430.7934.xml')"),
+});
+
+const BackupDownloadSchema = z.object({
+  backup_id: z
+    .string()
+    .optional()
+    .describe("Specific backup ID to download. If omitted, downloads the current running config."),
+});
+
 // ---------------------------------------------------------------------------
 // Tool definitions (for ListTools)
 // ---------------------------------------------------------------------------
@@ -23,9 +34,41 @@ export const systemToolDefinitions = [
     inputSchema: { type: "object" as const, properties: {} },
   },
   {
-    name: "opnsense_sys_backup",
-    description: "Create a configuration backup of the OPNsense system",
+    name: "opnsense_sys_backup_list",
+    description:
+      "List all configuration backups stored on the OPNsense filesystem with timestamps, descriptions, and file sizes",
     inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_sys_backup_download",
+    description:
+      "Download an OPNsense configuration backup as XML. Downloads the current running config if no backup_id is specified.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        backup_id: {
+          type: "string",
+          description:
+            "Specific backup ID to download (e.g. 'config-1773423430.7934.xml'). Omit to download the current running config.",
+        },
+      },
+    },
+  },
+  {
+    name: "opnsense_sys_backup_revert",
+    description:
+      "Revert OPNsense configuration to a previous backup. DESTRUCTIVE: replaces the running config with the specified backup.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        backup_id: {
+          type: "string",
+          description:
+            "Backup ID to revert to (e.g. 'config-1773423430.7934.xml'). Use opnsense_sys_backup_list to see available backups.",
+        },
+      },
+      required: ["backup_id"],
+    },
   },
   {
     name: "opnsense_sys_list_certs",
@@ -75,8 +118,25 @@ export async function handleSystemTool(
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
-      case "opnsense_sys_backup": {
-        const result = await client.post("/core/backup/backup");
+      case "opnsense_sys_backup_list": {
+        const result = await client.get("/core/backup/backups/this");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_sys_backup_download": {
+        const parsed = BackupDownloadSchema.parse(args);
+        const backupPath = parsed.backup_id
+          ? `/core/backup/download/this/${encodeURIComponent(parsed.backup_id)}`
+          : "/core/backup/download/this";
+        const xml = await client.getRaw(backupPath);
+        return { content: [{ type: "text", text: xml }] };
+      }
+
+      case "opnsense_sys_backup_revert": {
+        const parsed = BackupRevertSchema.parse(args);
+        const result = await client.post(
+          `/core/backup/revertBackup/${encodeURIComponent(parsed.backup_id)}`,
+        );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 

--- a/tests/tools/system.test.ts
+++ b/tests/tools/system.test.ts
@@ -13,8 +13,8 @@ function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
 }
 
 describe('System Tool Definitions', () => {
-  it('exports 5 tool definitions', () => {
-    expect(systemToolDefinitions).toHaveLength(5);
+  it('exports 7 tool definitions', () => {
+    expect(systemToolDefinitions).toHaveLength(7);
   });
 
   it('all tools have opnsense_ prefix', () => {
@@ -42,14 +42,49 @@ describe('handleSystemTool', () => {
     expect(client.get).toHaveBeenCalledWith('/core/system/status');
   });
 
-  it('creates a backup', async () => {
+  it('lists backups', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({
+        items: [{ id: 'config-123.xml', time_iso: '2026-03-13T16:00:00+00:00', description: 'test' }],
+      }),
+    });
+
+    const result = await handleSystemTool('opnsense_sys_backup_list', {}, client);
+    expect(result.content[0].text).toContain('config-123.xml');
+    expect(client.get).toHaveBeenCalledWith('/core/backup/backups/this');
+  });
+
+  it('downloads current config', async () => {
+    const client = mockClient({
+      getRaw: vi.fn().mockResolvedValue('<opnsense><system></system></opnsense>'),
+    });
+
+    const result = await handleSystemTool('opnsense_sys_backup_download', {}, client);
+    expect(result.content[0].text).toContain('<opnsense>');
+    expect(client.getRaw).toHaveBeenCalledWith('/core/backup/download/this');
+  });
+
+  it('downloads specific backup by id', async () => {
+    const client = mockClient({
+      getRaw: vi.fn().mockResolvedValue('<opnsense></opnsense>'),
+    });
+
+    const result = await handleSystemTool('opnsense_sys_backup_download', {
+      backup_id: 'config-123.xml',
+    }, client);
+    expect(client.getRaw).toHaveBeenCalledWith('/core/backup/download/this/config-123.xml');
+  });
+
+  it('reverts to a backup', async () => {
     const client = mockClient({
       post: vi.fn().mockResolvedValue({ status: 'ok' }),
     });
 
-    const result = await handleSystemTool('opnsense_sys_backup', {}, client);
+    const result = await handleSystemTool('opnsense_sys_backup_revert', {
+      backup_id: 'config-123.xml',
+    }, client);
     expect(result.content[0].text).toContain('ok');
-    expect(client.post).toHaveBeenCalledWith('/core/backup/backup');
+    expect(client.post).toHaveBeenCalledWith('/core/backup/revertBackup/config-123.xml');
   });
 
   it('lists certificates from trust store', async () => {


### PR DESCRIPTION
## Summary
- Replace broken `opnsense_sys_backup` (endpoint removed in OPNsense 24.7) with 3 new tools
- Add `opnsense_sys_backup_list` — list all configuration backups with timestamps
- Add `opnsense_sys_backup_download` — download config XML (current or specific backup)
- Add `opnsense_sys_backup_revert` — revert to a previous backup (destructive)
- Add `/backup` slash command skill for configuration backup management
- Tool count: 60 → 62, tests: 65 → 68

Closes #43

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 68 tests pass
- [ ] Live test: `opnsense_sys_backup_list` returns backup list
- [ ] Live test: `opnsense_sys_backup_download` returns XML
- [ ] Live test: `/backup` skill shows dashboard