### PR TITLE
docs: add badges and ToC to README and CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.13.18
+
+- Add shields.io badges to README.md (release, license, CalVer, Node.js, MCP tools, TypeScript) (#53)
+- Add table of contents to README.md and CLAUDE.md (#53)
+
 ## v2026.03.13.17
 
 - Fix 7 OPNsense 24.7 API compatibility issues discovered during live testing (#45, #46, #47, #48, #49, #50, #51):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,20 @@
 # mcp-opnsense — CLAUDE.md
 
+## Table of Contents
+
+- [Project Overview](#project-overview)
+- [Architecture](#architecture)
+- [Code Conventions](#code-conventions)
+- [Security](#security)
+- [Design/Plan Documents — MANDATORY](#designplan-documents--mandatory)
+- [CHANGELOG.md — MANDATORY](#changelogmd--mandatory)
+- [Versioning & Releases (CalVer)](#versioning--releases-calver)
+- [Git Workflow](#git-workflow)
+- [Claude Code Skills](#claude-code-skills)
+- [Language](#language)
+- [Development Setup](#development-setup)
+- [Testing](#testing)
+
 ## Project Overview
 
 Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense REST API. Provides ~62 granular tools for DNS, Firewall, Diagnostics, Interfaces, DHCP, System, ACME, and Firmware management.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
 # mcp-opnsense
 
+[![GitHub release](https://img.shields.io/github/v/release/itunified-io/mcp-opnsense?style=flat-square)](https://github.com/itunified-io/mcp-opnsense/releases)
+[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square)](LICENSE)
+[![CalVer](https://img.shields.io/badge/calver-YYYY.0M.DD.MICRO-22bfae?style=flat-square)](https://calver.org)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen?style=flat-square)](https://nodejs.org)
+[![MCP Tools](https://img.shields.io/badge/MCP_tools-62-purple?style=flat-square)](#available-tools-62)
+[![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square)](https://www.typescriptlang.org/)
+
 Slim OPNsense MCP Server for managing firewall infrastructure via the OPNsense REST API.
 
 **No SSH. No shell execution. API-only. 3 runtime dependencies.**
+
+## Table of Contents
+
+- [Features](#features)
+- [Quick Start](#quick-start)
+- [Claude Code Integration](#claude-code-integration)
+- [Environment Variables](#environment-variables)
+- [Available Tools (62)](#available-tools-62)
+- [Claude Code Skills](#claude-code-skills)
+- [Known Limitations](#known-limitations)
+- [Security](#security)
+- [Development](#development)
+- [License](#license)
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Add shields.io badges to README.md (release, license, CalVer, Node.js, MCP tools, TypeScript)
- Add table of contents to README.md and CLAUDE.md
- Follows ADR-0006 (badge standardization) and ADR-0007 (mandatory ToC) from infrastructure repo

Closes #53

## Test plan

- [ ] Badges render correctly on GitHub
- [ ] ToC anchor links work in README.md
- [ ] ToC anchor links work in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)