### PR TITLE
fix: replace Slack email with GitHub Security Advisories in SECURITY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.13.19
+
+- Fix SECURITY.md: replace internal Slack email with GitHub Security Advisories (#55)
+- Scrub Slack workspace email from git history (#55)
+
 ## v2026.03.13.18
 
 - Add shields.io badges to README.md (release, license, CalVer, Node.js, MCP tools, TypeScript) (#53)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@
 If you discover a security vulnerability, please report it responsibly:
 
 1. **Do NOT** create a public GitHub issue
-2. Report via Slack: [#opnsense-mcp](mailto:opensense-mcp-aaaatnycbrg3prlpspwfcppf5e@itunified-workspace.slack.com) or email the Slack channel at `opensense-mcp-aaaatnycbrg3prlpspwfcppf5e@itunified-workspace.slack.com`
+2. Use [GitHub Security Advisories](https://github.com/itunified-io/mcp-opnsense/security/advisories/new) to report privately
 3. Include: description, steps to reproduce, potential impact
 
 We will respond within 48 hours and work with you on a fix before public disclosure.


### PR DESCRIPTION
## Summary

- Replace internal Slack workspace email with GitHub Security Advisories link in SECURITY.md
- Slack email violated ADR-0004 (public repo docs policy) by exposing internal workspace name
- Git history scrub will follow after merge

Closes #55

## Test plan

- [ ] SECURITY.md no longer contains Slack email
- [ ] Security Advisories link is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)