### PR TITLE
Rename slash commands per ADR-0010 naming convention

### DIFF
--- a/.claude/skills/opnsense-acme-renew/SKILL.md
+++ b/.claude/skills/opnsense-acme-renew/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: opnsense-acme-renew
+name: opn-renew-cert
 description: Check ACME certificate expiry and renew if needed — lists all certs, shows days remaining, triggers renewal
 disable-model-invocation: true
 ---
 
-# OPNsense ACME Certificate Renewal (/renew-cert)
+# OPNsense ACME Certificate Renewal (/opn-renew-cert)
 
 Check ACME certificate status and renew certificates approaching expiry.
 

--- a/.claude/skills/opnsense-backup/SKILL.md
+++ b/.claude/skills/opnsense-backup/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: opnsense-backup
+name: opn-backup
 description: OPNsense configuration backup management — list, download, and revert backups
 disable-model-invocation: true
 ---
 
-# /backup — OPNsense Configuration Backup
+# /opn-backup — OPNsense Configuration Backup
 
 Manage OPNsense configuration backups: list available backups, download config XML, and revert to a previous configuration.
 

--- a/.claude/skills/opnsense-service-health/SKILL.md
+++ b/.claude/skills/opnsense-service-health/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: opnsense-service-health
+name: opn-health
 description: Dashboard-style health overview of the OPNsense firewall — system status, services, firmware, interfaces, DHCP
 disable-model-invocation: true
 ---
 
-# OPNsense Health Check (/health)
+# OPNsense Health Check (/opn-health)
 
 Produce a dashboard-style health overview of the OPNsense firewall.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.14.1
+
+- Rename slash commands per ADR-0010 naming convention (#57):
+  - `/health` → `/opn-health`
+  - `/backup` → `/opn-backup`
+  - `/renew-cert` → `/opn-renew-cert`
+- Update CLAUDE.md naming convention to document `/<system-short>-<action>` pattern
+
 ## v2026.03.13.19
 
 - Fix SECURITY.md: replace internal Slack email with GitHub Security Advisories (#55)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ disable-model-invocation: true   # Optional: makes it user-only (slash command)
 
 ### Naming Convention
 - Skill directory: `opnsense-<purpose>` (e.g., `opnsense-diagnostics`, `opnsense-service-health`)
-- Slash commands: short, memorable (e.g., `/health`, `/renew-cert`)
+- Slash commands: `/<system-short>-<action>` — use `opn` prefix (e.g., `/opn-health`, `/opn-backup`, `/opn-renew-cert`)
 
 ### Skill Design Guidelines
 - Each skill MUST specify which MCP tools it uses

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified/mcp-opnsense",
-  "version": "2026.3.13",
+  "version": "2026.3.14",
   "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Rename `/health` → `/opn-health`, `/backup` → `/opn-backup`, `/renew-cert` → `/opn-renew-cert`
- Update CLAUDE.md naming convention to document `/<system-short>-<action>` pattern
- Ensures unambiguous slash commands as we add Cloudflare (`/cf-*`) and Tailscale (`/ts-*`) MCP servers

Closes #57
Related: itunified-io/infrastructure#30

## Test plan
- [ ] Verify `/opn-health` triggers the service health skill
- [ ] Verify `/opn-backup` triggers the backup skill
- [ ] Verify `/opn-renew-cert` triggers the ACME renewal skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)