### PR TITLE
Add docs/superpowers/ to .gitignore (ADR-0021)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ dist/
 
 # Test coverage
 coverage/
+
+# Superpowers plugin working artifacts (ADR-0021)
+docs/superpowers/


### PR DESCRIPTION
## Summary
- Add docs/superpowers/ to .gitignore per ADR-0021 in the infrastructure repo
- Prevents Superpowers plugin working artifacts from being committed

Closes #69

Generated with Claude Code