### PR TITLE
chore: add .mcpregistry_* to .gitignore (ADR-0024) (#76)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ coverage/
 
 # Superpowers plugin working artifacts (ADR-0021)
 docs/superpowers/
+
+# MCP Registry tokens (ADR-0024)
+.mcpregistry_*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.16.1
+
+- Add `.mcpregistry_*` to `.gitignore` and update CLAUDE.md security section (ADR-0024) (#76)
+
 ## v2026.03.15.2
 
 - Switch Glama badge from score to card format (#67)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ docs/
 - **Error handling**: No credential leaks in error messages
 - **Credentials**: Never hardcoded, never logged, never in git
 - **Secret Redaction — MANDATORY**: When using `grep`, `cat`, `sed`, `awk`, shell scripts, or any tool that reads/displays file contents containing secrets (`.env`, credentials, API keys, tokens, passwords), **ALWAYS redact the secret values** in output. Use patterns like `sed 's/=.*/=<redacted>/'` or equivalent. Never display raw secret values in terminal output, logs, conversation context, or commit messages.
+- **MCP Registry Tokens**: `.mcpregistry_*` files are gitignored (ADR-0024). Never commit registry auth tokens.
 - **Public Repo Documentation Policy — MANDATORY**: This is a **public repository**. All documentation, code examples, test data, and commit messages MUST use only generic placeholders:
   - Hostnames: `your-opnsense.example.com`, `fw.example.com`
   - IPs: `192.168.1.1`, `10.0.0.1` (common private ranges only)


### PR DESCRIPTION
## Summary
- Add `.mcpregistry_*` to `.gitignore` to prevent MCP registry token files from being committed
- Add MCP Registry Tokens entry to CLAUDE.md security section
- Per ADR-0024 in infrastructure repo

Closes #76

## Test plan
- [x] `.mcpregistry_*` files never in git history
- [x] `.gitignore` updated
- [x] CLAUDE.md security section updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)