### PR TITLE
feat: add opnsense-helpers/ PHP scripts (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.04.09.4
+
+- **Add `opnsense-helpers/` PHP scripts for SSH-backed interface assignment** (#95)
+  - New `opnsense-helpers/if_assign.php` — assign an existing VLAN / NIC device to a free `optN` slot
+  - New `opnsense-helpers/if_configure.php` — set IPv4 / IPv6 on an already-assigned `optN` slot (static, dhcp, dhcp6, track6, none)
+  - New `opnsense-helpers/README.md` — install procedure + recommended `sudoers.d` whitelist template
+  - Fills the gap where the OPNsense REST API has no "Interfaces → Assignments" endpoint
+  - Both helpers mirror `interfaces_assign.php` requires (`config.inc`, `filter.inc`, `system.inc`, `interfaces.inc`, `util.inc`)
+  - `interfaces_configure()` / `filter_configure()` calls are wrapped in `ob_start()` / `ob_end_clean()` so stdout stays a single JSON object
+  - Strict argument validation: slot regex, device regex, description charset, `filter_var()` IP checks, CIDR range
+  - Numbered exit codes: `0` success, `1` invalid args, `2` state error, `3` validation, `4` write_config failed, `5` interfaces_configure failed
+  - Every `write_config()` call is stamped `mcp-opnsense: ...` so mutations are traceable in the OPNsense backup history
+  - Validated end-to-end on OPNsense 24.7 (assign + configure with `ipaddr=none`, read-back, revert)
+  - Server-side only — SSH client tools (`opnsense_if_assign`, `opnsense_if_configure`) ship in a follow-up release
+
 ## v2026.04.09.3
 
 - **Vault AppRole secret loading** (#93)

--- a/opnsense-helpers/README.md
+++ b/opnsense-helpers/README.md
@@ -1,0 +1,68 @@
+# OPNsense PHP helpers
+
+Server-side PHP scripts that mcp-opnsense invokes over SSH + sudo for operations
+the OPNsense REST API does not expose.
+
+## Why
+
+The OPNsense REST API covers most infrastructure operations, but a few legacy
+pages have no API equivalent. The most notable gap is **Interfaces →
+Assignments**: there is no REST endpoint to bind a VLAN or NIC device to a
+free `optN` slot, which is a prerequisite for configuring an IP on it.
+
+These helpers fill that gap. They live inside mcp-opnsense so that the tool and
+the remote script that implements it are versioned and released together.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `if_assign.php` | Assign an existing VLAN or NIC device to a free `optN` slot |
+| `if_configure.php` | Set IPv4/IPv6 on an already-assigned `optN` slot (static, dhcp, dhcp6, track6, none) |
+
+Both helpers:
+
+- Require OPNsense 24.x or later (tested on 24.7)
+- Must be run as root (typically via `sudo`)
+- Emit a single JSON object on stdout
+- Use numbered exit codes (see the file-level docblock in each script)
+
+## Install
+
+On the target OPNsense host:
+
+```sh
+sudo mkdir -p /usr/local/opnsense/scripts/mcp
+sudo install -m 0755 -o root -g wheel if_assign.php    /usr/local/opnsense/scripts/mcp/
+sudo install -m 0755 -o root -g wheel if_configure.php /usr/local/opnsense/scripts/mcp/
+```
+
+## Sudoers whitelist (recommended)
+
+Create `/usr/local/etc/sudoers.d/mcp_opnsense` (mode `0440`, owner `root:wheel`)
+to authorize the mcp-opnsense user without requiring a blanket wheel NOPASSWD
+grant:
+
+```
+Defaults:<user>    !lecture, !authenticate, !requiretty, env_reset
+<user> ALL=(root) NOPASSWD: \
+    /usr/local/sbin/configctl interface reconfigure, \
+    /usr/local/sbin/configctl filter reload, \
+    /usr/local/bin/php -f /usr/local/opnsense/scripts/mcp/if_assign.php *, \
+    /usr/local/bin/php -f /usr/local/opnsense/scripts/mcp/if_configure.php *, \
+    /bin/cat /conf/config.xml
+```
+
+Replace `<user>` with the login name mcp-opnsense uses for SSH. Validate with
+`visudo -c -f /usr/local/etc/sudoers.d/mcp_opnsense` before leaving the host.
+
+## Security
+
+- The helpers validate every argument (slot format, device format, description
+  charset, IP address, CIDR range) before touching `$config`
+- The description charset is restricted to prevent XML injection into
+  `config.xml`
+- Only pre-existing VLANs (from `<vlans>`) or real NICs (from
+  `get_interface_list()`) may be assigned — there is no free-form device input
+  path
+- The helpers never read credentials, tokens, or secrets

--- a/opnsense-helpers/if_assign.php
+++ b/opnsense-helpers/if_assign.php
@@ -1,0 +1,152 @@
+#!/usr/local/bin/php
+<?php
+/**
+ * if_assign.php — assign an existing interface (VLAN / NIC) to a free opt slot.
+ *
+ * Used by mcp-opnsense (via SSH + sudo) to fill the gap in the OPNsense REST API,
+ * which does not expose the legacy "Assign interfaces" page.
+ *
+ * Delivery: installed to /usr/local/opnsense/scripts/mcp/if_assign.php on the
+ * target OPNsense host (mode 0755, root:wheel) and invoked only via a sudoers
+ * whitelist drop-in (see mcp-opnsense README for the recommended pattern).
+ *
+ * Usage:
+ *   sudo php -f /usr/local/opnsense/scripts/mcp/if_assign.php \
+ *       --slot=<optN> --if=<device> [--descr=<text>]
+ *
+ * Examples:
+ *   --slot=opt1 --if=vlan10 --descr="home VLAN"
+ *   --slot=opt2 --if=vlan20 --descr="mgmt VLAN"
+ *
+ * Exit codes:
+ *   0 success, assignment written and interface brought up
+ *   1 invalid arguments
+ *   2 slot already assigned
+ *   3 unknown device (not in <vlans> and not a real NIC)
+ *   4 write_config failed
+ *   5 interfaces_configure failed
+ *
+ * Output: single JSON object on stdout.
+ *
+ * Source of truth: itunified-io/mcp-opnsense — opnsense-helpers/
+ */
+
+require_once("config.inc");
+require_once("filter.inc");
+require_once("system.inc");
+require_once("interfaces.inc");
+require_once("util.inc");
+
+function out_json(array $obj): void
+{
+    echo json_encode($obj, JSON_UNESCAPED_SLASHES) . "\n";
+}
+
+function fail(int $code, string $msg, array $extra = []): void
+{
+    out_json(array_merge(["ok" => false, "error" => $msg], $extra));
+    exit($code);
+}
+
+// --- 1. Parse argv ---
+$opts = getopt("", ["slot:", "if:", "descr::"]);
+if (empty($opts["slot"]) || empty($opts["if"])) {
+    fail(1, "missing required arguments",
+         ["usage" => "--slot=<optN> --if=<device> [--descr=<text>]"]);
+}
+
+$slot  = trim($opts["slot"]);
+$ifdev = trim($opts["if"]);
+$descr = isset($opts["descr"]) ? trim($opts["descr"]) : "";
+
+// --- 2. Validate slot format ---
+if (!preg_match('/^opt\d+$/', $slot)) {
+    fail(1, "invalid slot format (expected optN)", ["slot" => $slot]);
+}
+
+// --- 3. Validate device format (safe subset) ---
+if (!preg_match('/^(vlan\d+|[a-z]+\d+(_vlan\d+)?)$/', $ifdev)) {
+    fail(1, "invalid device format", ["if" => $ifdev]);
+}
+
+// --- 4. Validate description charset (prevent XML injection) ---
+if ($descr !== "" && !preg_match('/^[\w\s\-\.\,\(\)\#\:\/]{1,120}$/u', $descr)) {
+    fail(1, "description contains disallowed characters", ["descr" => $descr]);
+}
+
+global $config;
+
+// --- 5. Slot must not already exist ---
+if (isset($config["interfaces"][$slot])) {
+    fail(2, "slot already assigned",
+         ["slot" => $slot,
+          "current" => $config["interfaces"][$slot]["if"] ?? "?"]);
+}
+
+// --- 6. Device must exist as a VLAN or be a real NIC ---
+$known_vlans = [];
+if (isset($config["vlans"]["vlan"]) && is_array($config["vlans"]["vlan"])) {
+    foreach ($config["vlans"]["vlan"] as $v) {
+        if (isset($v["vlanif"])) {
+            $known_vlans[] = $v["vlanif"];
+        }
+    }
+}
+
+$device_exists = in_array($ifdev, $known_vlans, true);
+if (!$device_exists) {
+    // Check if it's a real NIC (listed by kernel)
+    $real_nics = get_interface_list();
+    if (isset($real_nics[$ifdev])) {
+        $device_exists = true;
+    }
+}
+
+if (!$device_exists) {
+    fail(3, "device not found in <vlans> and not a real NIC",
+         ["if" => $ifdev, "known_vlans" => $known_vlans]);
+}
+
+// --- 7. Patch config.xml in memory ---
+$config["interfaces"][$slot] = [
+    "if"        => $ifdev,
+    "enable"    => "1",
+    "descr"     => $descr,
+    "ipaddr"    => "none",
+    "ipaddrv6"  => "none",
+    "media"     => "",
+    "mediaopt"  => "",
+    "spoofmac"  => "",
+];
+
+// --- 8. Persist ---
+$msg = "mcp-opnsense: assigned {$ifdev} to {$slot}" .
+       ($descr !== "" ? " ({$descr})" : "");
+if (!write_config($msg)) {
+    fail(4, "write_config failed", ["slot" => $slot, "if" => $ifdev]);
+}
+
+// --- 9. Bring the slot up (enable the interface) ---
+// interfaces_configure() writes progress messages to stdout ("Configuring ...done.")
+// which would corrupt the single-JSON-object stdout contract. Buffer and discard.
+ob_start();
+try {
+    interfaces_configure($slot);
+    ob_end_clean();
+} catch (Throwable $e) {
+    ob_end_clean();
+    fail(5, "interfaces_configure failed", [
+        "slot"  => $slot,
+        "error" => $e->getMessage(),
+    ]);
+}
+
+// --- 10. Success ---
+out_json([
+    "ok"     => true,
+    "slot"   => $slot,
+    "if"     => $ifdev,
+    "descr"  => $descr,
+    "action" => "assigned_and_enabled",
+]);
+exit(0);

--- a/opnsense-helpers/if_configure.php
+++ b/opnsense-helpers/if_configure.php
@@ -1,0 +1,231 @@
+#!/usr/local/bin/php
+<?php
+/**
+ * if_configure.php — configure IPv4/IPv6 settings on an already-assigned opt slot.
+ *
+ * Used by mcp-opnsense (via SSH + sudo) to set IP addresses on interfaces that
+ * were already assigned via if_assign.php or through the legacy Web UI.
+ *
+ * Delivery: installed to /usr/local/opnsense/scripts/mcp/if_configure.php on the
+ * target OPNsense host (mode 0755, root:wheel) and invoked only via a sudoers
+ * whitelist drop-in (see mcp-opnsense README for the recommended pattern).
+ *
+ * Usage:
+ *   sudo php -f /usr/local/opnsense/scripts/mcp/if_configure.php \
+ *       --slot=<optN> \
+ *       [--ipv4=<addr|none|dhcp>] [--subnet=<n>] \
+ *       [--ipv6=<addr|none|dhcp6|track6>] [--subnetv6=<n>] \
+ *       [--track6-interface=<wan>] [--track6-prefix-id=<n>] \
+ *       [--descr=<text>] \
+ *       [--no-filter-reload]
+ *
+ * Examples:
+ *   --slot=opt2 --ipv4=192.0.2.1 --subnet=24 --descr="example VLAN"
+ *   --slot=opt1 --ipv4=198.51.100.1 --subnet=24 --ipv6=track6 --subnetv6=64 \
+ *               --track6-interface=wan --track6-prefix-id=1
+ *
+ * Exit codes:
+ *   0 success
+ *   1 invalid arguments
+ *   2 slot not assigned
+ *   3 validation failed (IP/CIDR format)
+ *   4 write_config failed
+ *   5 interfaces_configure failed
+ *
+ * Output: single JSON object on stdout.
+ *
+ * Source of truth: itunified-io/mcp-opnsense — opnsense-helpers/
+ */
+
+require_once("config.inc");
+require_once("filter.inc");
+require_once("system.inc");
+require_once("interfaces.inc");
+require_once("util.inc");
+
+function out_json(array $obj): void
+{
+    echo json_encode($obj, JSON_UNESCAPED_SLASHES) . "\n";
+}
+
+function fail(int $code, string $msg, array $extra = []): void
+{
+    out_json(array_merge(["ok" => false, "error" => $msg], $extra));
+    exit($code);
+}
+
+// --- 1. Parse argv ---
+$opts = getopt("", [
+    "slot:",
+    "ipv4::", "subnet::",
+    "ipv6::", "subnetv6::",
+    "track6-interface::", "track6-prefix-id::",
+    "descr::",
+    "no-filter-reload",
+]);
+
+if (empty($opts["slot"])) {
+    fail(1, "missing required argument --slot",
+         ["usage" => "--slot=<optN> [--ipv4=...] [--subnet=...] [--ipv6=...] [...]"]);
+}
+
+$slot = trim($opts["slot"]);
+if (!preg_match('/^opt\d+$/', $slot)) {
+    fail(1, "invalid slot format (expected optN)", ["slot" => $slot]);
+}
+
+global $config;
+
+// --- 2. Slot must exist ---
+if (!isset($config["interfaces"][$slot])) {
+    fail(2, "slot not assigned — run if_assign.php first", ["slot" => $slot]);
+}
+
+// --- 3. Validate IPv4 ---
+$ipv4   = isset($opts["ipv4"])   ? trim($opts["ipv4"])   : null;
+$subnet = isset($opts["subnet"]) ? trim($opts["subnet"]) : null;
+
+if ($ipv4 !== null && $ipv4 !== "" && $ipv4 !== "none" && $ipv4 !== "dhcp") {
+    if (!filter_var($ipv4, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+        fail(3, "invalid IPv4 address", ["ipv4" => $ipv4]);
+    }
+    if ($subnet === null || !ctype_digit($subnet) ||
+        (int)$subnet < 0 || (int)$subnet > 32) {
+        fail(3, "invalid --subnet for static IPv4 (0..32)",
+             ["subnet" => $subnet]);
+    }
+}
+
+// --- 4. Validate IPv6 ---
+$ipv6     = isset($opts["ipv6"])     ? trim($opts["ipv6"])     : null;
+$subnetv6 = isset($opts["subnetv6"]) ? trim($opts["subnetv6"]) : null;
+$track6if = isset($opts["track6-interface"]) ? trim($opts["track6-interface"]) : null;
+$track6id = isset($opts["track6-prefix-id"]) ? trim($opts["track6-prefix-id"]) : null;
+
+$ipv6_is_literal = ($ipv6 !== null && $ipv6 !== "" && $ipv6 !== "none" &&
+                    $ipv6 !== "dhcp6" && $ipv6 !== "track6");
+if ($ipv6_is_literal) {
+    if (!filter_var($ipv6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+        fail(3, "invalid IPv6 address", ["ipv6" => $ipv6]);
+    }
+    if ($subnetv6 === null || !ctype_digit($subnetv6) ||
+        (int)$subnetv6 < 0 || (int)$subnetv6 > 128) {
+        fail(3, "invalid --subnetv6 for static IPv6 (0..128)",
+             ["subnetv6" => $subnetv6]);
+    }
+}
+
+if ($ipv6 === "track6") {
+    if ($track6if === null ||
+        !preg_match('/^(wan|opt\d+|lan)$/', $track6if)) {
+        fail(3, "track6 requires --track6-interface=<parent>",
+             ["track6-interface" => $track6if]);
+    }
+    if ($track6id !== null && !ctype_digit($track6id)) {
+        fail(3, "--track6-prefix-id must be numeric", ["track6-prefix-id" => $track6id]);
+    }
+}
+
+// --- 5. Validate description ---
+$descr = isset($opts["descr"]) ? trim($opts["descr"]) : null;
+if ($descr !== null && $descr !== "" &&
+    !preg_match('/^[\w\s\-\.\,\(\)\#\:\/]{1,120}$/u', $descr)) {
+    fail(1, "description contains disallowed characters", ["descr" => $descr]);
+}
+
+// --- 6. Patch config in memory ---
+$iface =& $config["interfaces"][$slot];
+
+if ($ipv4 !== null) {
+    if ($ipv4 === "none" || $ipv4 === "") {
+        $iface["ipaddr"] = "none";
+        unset($iface["subnet"]);
+    } elseif ($ipv4 === "dhcp") {
+        $iface["ipaddr"] = "dhcp";
+        unset($iface["subnet"]);
+    } else {
+        $iface["ipaddr"] = $ipv4;
+        $iface["subnet"] = $subnet;
+    }
+}
+
+if ($ipv6 !== null) {
+    if ($ipv6 === "none" || $ipv6 === "") {
+        $iface["ipaddrv6"] = "none";
+        unset($iface["subnetv6"], $iface["track6-interface"], $iface["track6-prefix-id"]);
+    } elseif ($ipv6 === "dhcp6") {
+        $iface["ipaddrv6"] = "dhcp6";
+        unset($iface["subnetv6"], $iface["track6-interface"], $iface["track6-prefix-id"]);
+    } elseif ($ipv6 === "track6") {
+        $iface["ipaddrv6"] = "track6";
+        $iface["track6-interface"] = $track6if;
+        if ($track6id !== null) {
+            $iface["track6-prefix-id"] = $track6id;
+        }
+        unset($iface["subnetv6"]);
+    } else {
+        $iface["ipaddrv6"] = $ipv6;
+        $iface["subnetv6"] = $subnetv6;
+        unset($iface["track6-interface"], $iface["track6-prefix-id"]);
+    }
+}
+
+if ($descr !== null) {
+    $iface["descr"] = $descr;
+}
+
+// --- 7. Persist ---
+$summary = "mcp-opnsense: configured {$slot}";
+if ($ipv4 !== null)  { $summary .= " ipv4={$ipv4}" . ($subnet !== null ? "/{$subnet}" : ""); }
+if ($ipv6 !== null)  { $summary .= " ipv6={$ipv6}"; }
+if ($descr !== null) { $summary .= " descr=\"{$descr}\""; }
+
+if (!write_config($summary)) {
+    fail(4, "write_config failed", ["slot" => $slot]);
+}
+
+// --- 8. Apply ---
+// interfaces_configure() + filter_configure() both write progress to stdout,
+// which would corrupt the single-JSON-object stdout contract. Buffer and discard.
+ob_start();
+try {
+    interfaces_configure($slot);
+    ob_end_clean();
+} catch (Throwable $e) {
+    ob_end_clean();
+    fail(5, "interfaces_configure failed", [
+        "slot"  => $slot,
+        "error" => $e->getMessage(),
+    ]);
+}
+
+if (!isset($opts["no-filter-reload"])) {
+    ob_start();
+    try {
+        filter_configure();
+        ob_end_clean();
+    } catch (Throwable $e) {
+        ob_end_clean();
+        // Non-fatal: config wrote OK, interface up, only filter reload failed
+        out_json([
+            "ok"       => true,
+            "slot"     => $slot,
+            "warning"  => "filter_configure failed: " . $e->getMessage(),
+            "action"   => "configured_without_filter_reload",
+        ]);
+        exit(0);
+    }
+}
+
+// --- 9. Success ---
+out_json([
+    "ok"      => true,
+    "slot"    => $slot,
+    "ipv4"    => $iface["ipaddr"]   ?? null,
+    "subnet"  => $iface["subnet"]   ?? null,
+    "ipv6"    => $iface["ipaddrv6"] ?? null,
+    "subnetv6"=> $iface["subnetv6"] ?? null,
+    "descr"   => $iface["descr"]    ?? null,
+    "action"  => "configured_and_applied",
+]);
+exit(0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified/mcp-opnsense",
-  "version": "2026.4.9-3",
+  "version": "2026.4.9-4",
   "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Add `opnsense-helpers/{if_assign.php, if_configure.php, README.md}` — server-side PHP scripts that fill the gap where the OPNsense REST API has no "Interfaces → Assignments" endpoint
- Both helpers mirror `interfaces_assign.php` requires, wrap stdout-polluting calls in `ob_start`/`ob_end_clean`, validate all arguments strictly, and stamp `write_config()` with `mcp-opnsense: ...` for audit traceability
- Server-side only — SSH client tools (`opnsense_if_assign`, `opnsense_if_configure`) ship in a follow-up release so operators can pre-install the helpers

Closes #95

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 101/101 passing
- [x] `php -l` clean on both helpers (pre-commit)
- [x] End-to-end dry-run on OPNsense 24.7: assign VLAN to optN + configure `ipaddr=none` + read-back + revert → clean round-trip
- [ ] Static IPv4 path exercised during real Phase 1 execution in the follow-up SSH-client release

## Release

- CHANGELOG entry added under `v2026.04.09.4`
- `package.json` bumped to `2026.4.9-4`
- Tag + GH release will be cut on merge