### PR TITLE
feat: SSH-backed opnsense_if_assign + opnsense_if_configure tools (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.04.09.5
+
+- **Add `opnsense_if_assign` and `opnsense_if_configure` SSH-backed tools** (#97)
+  - New `src/client/ssh-client.ts` — minimal SSH client backed by the system `ssh` binary via `spawn()` (no new runtime dependencies)
+  - Strict host key checking enforced via a required `OPNSENSE_SSH_KNOWN_HOSTS` file; no TOFU fallback
+  - `BatchMode=yes` + `PreferredAuthentications=publickey` disables password and keyboard-interactive auth
+  - Arguments are single-quote-escaped before concatenation into the remote command string — no argv breakout from untrusted tool input
+  - New env vars: `OPNSENSE_SSH_ENABLED`, `OPNSENSE_SSH_HOST`, `OPNSENSE_SSH_USER`, `OPNSENSE_SSH_KEY_PATH`, `OPNSENSE_SSH_KNOWN_HOSTS`, `OPNSENSE_SSH_PORT` (default 22), `OPNSENSE_SSH_HELPER_DIR` (default `/usr/local/opnsense/scripts/mcp`), `OPNSENSE_SSH_CONNECT_TIMEOUT` (default 10s)
+  - `opnsense_if_assign` — assign a VLAN/NIC device to a free `optN` slot (closes the gap where the OPNsense REST API has no "Interfaces → Assignments" endpoint)
+  - `opnsense_if_configure` — set IPv4/IPv6 on an already-assigned `optN` slot (static, dhcp, dhcp6, track6, none)
+  - Both tools fail fast with a clear error if `OPNSENSE_SSH_ENABLED` is not `true`, so non-SSH deployments are unaffected
+  - PHP `--` separator is inserted automatically (mandatory per ADR-0092 spike: PHP CLI would otherwise swallow `--slot=…` as its own option)
+  - Exit codes from the helpers are surfaced to the caller and mapped into the response payload
+  - 19 new unit tests (`tests/client/ssh-client.test.ts`) covering constructor validation, `fromEnv()` env-var requirements, SSH argv assembly, helper command building with the mandatory `--` separator, and shell quoting of metacharacter-laden values
+  - README: new "SSH-backed interface assignment" section with env var table, OPNsense host setup, mcp-opnsense host setup, and the full security posture
+  - Tool count: 85 → 87
+
 ## v2026.04.09.4
 
 - **Add `opnsense-helpers/` PHP scripts for SSH-backed interface assignment** (#95)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ Add to `.mcp.json` in your project root:
 | `NAS_VAULT_ROLE_ID` | No | — | Vault AppRole role_id |
 | `NAS_VAULT_SECRET_ID` | No | — | Vault AppRole secret_id |
 | `NAS_VAULT_KV_MOUNT` | No | `kv` | Vault KV v2 mount path |
+| `OPNSENSE_SSH_ENABLED` | No | `false` | Enable SSH-backed tools (`opnsense_if_assign`, `opnsense_if_configure`) — see below |
+| `OPNSENSE_SSH_HOST` | If SSH enabled | — | SSH hostname of the OPNsense target |
+| `OPNSENSE_SSH_USER` | If SSH enabled | — | SSH login user (must have `NOPASSWD` sudo for the helper scripts) |
+| `OPNSENSE_SSH_KEY_PATH` | If SSH enabled | — | Path to the private key (e.g. `~/.ssh/id_ed25519`) |
+| `OPNSENSE_SSH_KNOWN_HOSTS` | If SSH enabled | — | Path to a pre-populated `known_hosts` (strict checking, no TOFU) |
+| `OPNSENSE_SSH_PORT` | No | `22` | SSH port |
+| `OPNSENSE_SSH_HELPER_DIR` | No | `/usr/local/opnsense/scripts/mcp` | Remote directory holding `if_assign.php` / `if_configure.php` |
+| `OPNSENSE_SSH_CONNECT_TIMEOUT` | No | `10` | SSH connect timeout in seconds |
 
 ### Loading Secrets from a File
 
@@ -155,7 +163,7 @@ if nothing remains.
 populated-count appear in stderr diagnostics. The loader uses the global
 `fetch` (Node 20+) — no new runtime dependencies.
 
-## Available Tools (85)
+## Available Tools (87)
 
 ### DNS/Unbound (12 tools)
 
@@ -202,13 +210,66 @@ populated-count appear in stderr diagnostics. The loader uses the global
 | `opnsense_diag_fw_logs` | Retrieve recent firewall log entries |
 | `opnsense_diag_system_info` | Get system status (CPU, memory, uptime, disk) |
 
-### Interfaces (3 tools, read-only)
+### Interfaces (5 tools)
 
 | Tool | Description |
 |------|-------------|
 | `opnsense_if_list` | List all network interfaces with device mappings |
 | `opnsense_if_get` | Get detailed interface configuration |
 | `opnsense_if_stats` | Get traffic statistics for all interfaces |
+| `opnsense_if_assign` | **SSH-backed.** Assign a VLAN/NIC device to a free `optN` slot (gap in the OPNsense REST API) |
+| `opnsense_if_configure` | **SSH-backed.** Set IPv4/IPv6 on an already-assigned `optN` slot (static, dhcp, dhcp6, track6, none) |
+
+#### SSH-backed interface assignment
+
+`opnsense_if_assign` and `opnsense_if_configure` are the only tools that do
+not go through the OPNsense REST API. The REST API has no "Interfaces →
+Assignments" endpoint, so mcp-opnsense invokes two small PHP helpers over
+SSH + sudo instead. Both tools fail fast with a clear error if
+`OPNSENSE_SSH_ENABLED` is not `true`, so non-SSH deployments are unaffected.
+
+**Setup on the OPNsense host:**
+
+1. Install the helpers (shipped in this repo under `opnsense-helpers/`):
+   ```sh
+   sudo install -m 0755 -o root -g wheel if_assign.php    /usr/local/opnsense/scripts/mcp/
+   sudo install -m 0755 -o root -g wheel if_configure.php /usr/local/opnsense/scripts/mcp/
+   ```
+2. Create a dedicated SSH user with a public key and add a `sudoers.d` drop-in
+   that whitelists the exact helper invocations (see
+   `opnsense-helpers/README.md` for the recommended pattern — the glob MUST
+   end in `*` to accommodate the mandatory PHP `--` separator).
+
+**Setup on the mcp-opnsense host:**
+
+```sh
+export OPNSENSE_SSH_ENABLED=true
+export OPNSENSE_SSH_HOST=your-opnsense.example.com
+export OPNSENSE_SSH_USER=claude
+export OPNSENSE_SSH_KEY_PATH=~/.ssh/id_ed25519
+export OPNSENSE_SSH_KNOWN_HOSTS=~/.ssh/known_hosts
+```
+
+The `known_hosts` file must be pre-populated — mcp-opnsense enforces strict
+host key checking and will refuse to connect otherwise (no TOFU fallback).
+
+**Security posture:**
+
+- No shell is invoked locally; the client spawns `ssh` directly with an argv
+  array.
+- Arguments are single-quote-escaped before concatenation into the remote
+  command string, so untrusted tool input cannot break out of argv on the
+  remote side.
+- `BatchMode=yes` + `PreferredAuthentications=publickey` disables password
+  and keyboard-interactive auth.
+- The PHP helpers validate every argument (slot regex, device regex,
+  description charset, IP + CIDR) before touching `config.xml`, stamp every
+  `write_config()` with `mcp-opnsense: ...` for audit traceability, and use
+  numbered exit codes so the caller can distinguish "invalid args" from
+  "write_config failed" from "apply failed".
+
+See ADR-0092 (in the private infrastructure repo) for the full research
+spike, empirical findings, and rollback contract.
 
 ### DHCP (5 tools)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified/mcp-opnsense",
-  "version": "2026.4.9-4",
+  "version": "2026.4.9-5",
   "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/client/ssh-client.ts
+++ b/src/client/ssh-client.ts
@@ -1,0 +1,261 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+
+/**
+ * Configuration for the SSH client.
+ *
+ * All fields except `port` and `helperDir` are required. `fromEnv()` reads these
+ * from `OPNSENSE_SSH_*` environment variables and throws if any required value
+ * is missing or if the key / known_hosts files do not exist on disk.
+ */
+export interface SshClientConfig {
+  host: string;
+  user: string;
+  keyPath: string;
+  knownHostsPath: string;
+  port?: number;
+  helperDir?: string;
+  connectTimeoutSec?: number;
+}
+
+export interface SshRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * Helper-script JSON response. The PHP helpers in `opnsense-helpers/` emit a
+ * single JSON object on stdout. On success `ok=true`; on any failure the
+ * helper sets `ok=false` and the process exit code carries the error class
+ * (1 args, 2 state, 3 validation, 4 write_config, 5 interfaces_configure).
+ */
+export interface HelperResponse {
+  ok: boolean;
+  error?: string;
+  warning?: string;
+  [key: string]: unknown;
+}
+
+export class SshClientError extends Error {
+  constructor(
+    message: string,
+    public readonly exitCode: number | null,
+    public readonly stdout: string,
+    public readonly stderr: string,
+  ) {
+    super(message);
+    this.name = "SshClientError";
+  }
+}
+
+/**
+ * Minimal SSH client backed by the system `ssh` binary via `spawn()` with an
+ * argv array (no new runtime deps, no local shell).
+ *
+ * Security posture:
+ *   - Strict host key checking is enforced via `UserKnownHostsFile=<path>` +
+ *     `StrictHostKeyChecking=yes`. There is no TOFU fallback.
+ *   - Password / keyboard-interactive auth is disabled via
+ *     `PreferredAuthentications=publickey` + `BatchMode=yes`.
+ *   - Arguments are shell-quoted with a strict quoter before being
+ *     concatenated into the remote command string, so untrusted input cannot
+ *     break out of the intended argv on the remote side.
+ *   - No shell is invoked locally; we `spawn("ssh", [...])` directly. The
+ *     remote side DOES see a shell (sshd ExecShell), which is why the
+ *     per-argument quoting matters.
+ */
+export class SshClient {
+  constructor(private readonly config: SshClientConfig) {
+    if (!existsSync(config.keyPath)) {
+      throw new Error(`SSH key not found at ${config.keyPath}`);
+    }
+    if (!existsSync(config.knownHostsPath)) {
+      throw new Error(
+        `SSH known_hosts file not found at ${config.knownHostsPath} ` +
+          `(strict host key checking requires a pre-populated file)`,
+      );
+    }
+  }
+
+  /**
+   * Build an SshClient from `OPNSENSE_SSH_*` environment variables.
+   * Returns `null` if `OPNSENSE_SSH_ENABLED` is not `true`.
+   * Throws if SSH is enabled but required vars are missing or files don't exist.
+   */
+  static fromEnv(): SshClient | null {
+    const enabled = (process.env.OPNSENSE_SSH_ENABLED ?? "").toLowerCase();
+    if (enabled !== "true" && enabled !== "1" && enabled !== "yes") {
+      return null;
+    }
+
+    const host = requireEnv("OPNSENSE_SSH_HOST");
+    const user = requireEnv("OPNSENSE_SSH_USER");
+    const keyPath = expandTilde(requireEnv("OPNSENSE_SSH_KEY_PATH"));
+    const knownHostsPath = expandTilde(requireEnv("OPNSENSE_SSH_KNOWN_HOSTS"));
+    const port = process.env.OPNSENSE_SSH_PORT
+      ? Number.parseInt(process.env.OPNSENSE_SSH_PORT, 10)
+      : undefined;
+    const helperDir = process.env.OPNSENSE_SSH_HELPER_DIR;
+    const connectTimeoutSec = process.env.OPNSENSE_SSH_CONNECT_TIMEOUT
+      ? Number.parseInt(process.env.OPNSENSE_SSH_CONNECT_TIMEOUT, 10)
+      : undefined;
+
+    return new SshClient({
+      host,
+      user,
+      keyPath,
+      knownHostsPath,
+      port,
+      helperDir,
+      connectTimeoutSec,
+    });
+  }
+
+  /** Remote helper directory (defaults to `/usr/local/opnsense/scripts/mcp`). */
+  get helperDir(): string {
+    return this.config.helperDir ?? "/usr/local/opnsense/scripts/mcp";
+  }
+
+  /**
+   * Build the ssh(1) argv for the given remote command. Exposed for testing.
+   */
+  buildSshArgv(remoteCommand: string): string[] {
+    const argv: string[] = [
+      "-i",
+      this.config.keyPath,
+      "-o",
+      `UserKnownHostsFile=${this.config.knownHostsPath}`,
+      "-o",
+      "StrictHostKeyChecking=yes",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "PreferredAuthentications=publickey",
+      "-o",
+      `ConnectTimeout=${this.config.connectTimeoutSec ?? 10}`,
+    ];
+    if (this.config.port !== undefined) {
+      argv.push("-p", String(this.config.port));
+    }
+    argv.push(`${this.config.user}@${this.config.host}`, remoteCommand);
+    return argv;
+  }
+
+  /**
+   * Build the remote command string for a PHP helper invocation. Exposed for
+   * testing — the `--` separator is mandatory (ADR-0092): PHP CLI would
+   * otherwise swallow long options like `--slot=opt1` as its own arguments.
+   */
+  buildHelperCommand(script: string, args: string[]): string {
+    const absScript = `${this.helperDir}/${script}`;
+    return [
+      "sudo",
+      "php",
+      "-f",
+      shellQuote(absScript),
+      "--",
+      ...args.map(shellQuote),
+    ].join(" ");
+  }
+
+  /**
+   * Run a PHP helper with the given CLI arguments and parse the resulting
+   * single JSON object. Throws `SshClientError` if the helper cannot be run
+   * or if stdout is not valid JSON.
+   */
+  async runHelper(script: string, args: string[]): Promise<{
+    response: HelperResponse;
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+  }> {
+    const remoteCommand = this.buildHelperCommand(script, args);
+    const result = await this.runRemote(remoteCommand);
+
+    let response: HelperResponse;
+    try {
+      response = JSON.parse(result.stdout.trim()) as HelperResponse;
+    } catch {
+      throw new SshClientError(
+        `helper ${script} did not emit valid JSON on stdout (exit ${result.exitCode})`,
+        result.exitCode,
+        result.stdout,
+        result.stderr,
+      );
+    }
+
+    return {
+      response,
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  }
+
+  /**
+   * Run a raw command on the remote host. Prefer `runHelper()` for the PHP
+   * scripts — this is the low-level primitive.
+   */
+  runRemote(remoteCommand: string): Promise<SshRunResult> {
+    const argv = this.buildSshArgv(remoteCommand);
+    return new Promise((resolve, reject) => {
+      const child = spawn("ssh", argv, { stdio: ["ignore", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk.toString("utf8");
+      });
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk.toString("utf8");
+      });
+      child.on("error", (err) => {
+        reject(
+          new SshClientError(
+            `failed to spawn ssh: ${err.message}`,
+            null,
+            stdout,
+            stderr,
+          ),
+        );
+      });
+      child.on("close", (code) => {
+        resolve({ stdout, stderr, exitCode: code ?? -1 });
+      });
+    });
+  }
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim() === "") {
+    throw new Error(
+      `${name} is required when OPNSENSE_SSH_ENABLED=true (SSH-backed tools cannot run without it)`,
+    );
+  }
+  return value;
+}
+
+function expandTilde(path: string): string {
+  if (path.startsWith("~/")) {
+    return `${homedir()}/${path.slice(2)}`;
+  }
+  if (path === "~") {
+    return homedir();
+  }
+  return path;
+}
+
+/**
+ * POSIX shell quoter: wraps the string in single quotes and escapes embedded
+ * single quotes via the standard `'\''` pattern. Safe for any argv value.
+ */
+export function shellQuote(value: string): string {
+  if (value === "") return "''";
+  // Allow a conservative safe set to keep common invocations readable in logs.
+  if (/^[A-Za-z0-9_\-./:=@+,]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ for (const def of routingToolDefinitions) toolHandlers.set(def.name, handleRouti
 for (const def of vlanToolDefinitions) toolHandlers.set(def.name, handleVlanTool);
 
 const server = new Server(
-  { name: 'mcp-opnsense', version: '2026.4.9-3' },
+  { name: 'mcp-opnsense', version: '2026.4.9-5' },
   { capabilities: { tools: {} } }
 );
 

--- a/src/tools/interfaces.ts
+++ b/src/tools/interfaces.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { OPNsenseClient } from "../client/opnsense-client.js";
+import { SshClient } from "../client/ssh-client.js";
 
 // ---------------------------------------------------------------------------
 // Zod schemas for input validation
@@ -7,6 +8,30 @@ import type { OPNsenseClient } from "../client/opnsense-client.js";
 
 const GetInterfaceSchema = z.object({
   interface_name: z.string().min(1, "Interface name is required"),
+});
+
+const SlotRegex = /^opt\d+$/;
+const DeviceRegex = /^(vlan\d+|[a-z]+\d+(_vlan\d+)?)$/;
+const DescrRegex = /^[\w\s\-.,()#:/]{1,120}$/u;
+
+const IfAssignSchema = z.object({
+  slot: z.string().regex(SlotRegex, "slot must match /^opt\\d+$/ (e.g. opt1)"),
+  if: z
+    .string()
+    .regex(DeviceRegex, "device must be a VLAN (vlanNN) or a real NIC (e.g. igb0)"),
+  descr: z.string().regex(DescrRegex, "invalid description charset").optional(),
+});
+
+const IfConfigureSchema = z.object({
+  slot: z.string().regex(SlotRegex, "slot must match /^opt\\d+$/"),
+  ipv4: z.string().optional(),
+  subnet: z.union([z.string(), z.number()]).optional(),
+  ipv6: z.string().optional(),
+  subnetv6: z.union([z.string(), z.number()]).optional(),
+  track6_interface: z.string().optional(),
+  track6_prefix_id: z.union([z.string(), z.number()]).optional(),
+  descr: z.string().regex(DescrRegex, "invalid description charset").optional(),
+  no_filter_reload: z.boolean().optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -39,6 +64,80 @@ export const interfacesToolDefinitions = [
     description:
       "Get traffic statistics for all interfaces (bytes, packets, errors, collisions)",
     inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_if_assign",
+    description:
+      "Assign an existing VLAN or NIC device to a free optN slot via SSH. Requires OPNSENSE_SSH_ENABLED=true and the opnsense-helpers/if_assign.php script installed on the target host. Fills the gap where the OPNsense REST API has no 'Interfaces → Assignments' endpoint.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        slot: {
+          type: "string",
+          description: "Target slot (e.g. 'opt1', 'opt2'). Must be free.",
+        },
+        if: {
+          type: "string",
+          description:
+            "Device to assign (e.g. 'vlan10' for a VLAN or 'igb0' for a real NIC)",
+        },
+        descr: {
+          type: "string",
+          description: "Optional friendly description (max 120 chars)",
+        },
+      },
+      required: ["slot", "if"],
+    },
+  },
+  {
+    name: "opnsense_if_configure",
+    description:
+      "Configure IPv4/IPv6 on an already-assigned optN slot via SSH. Supports static, dhcp, dhcp6, track6, and 'none'. Requires OPNSENSE_SSH_ENABLED=true and the opnsense-helpers/if_configure.php script installed on the target host.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        slot: {
+          type: "string",
+          description: "Target slot (must already be assigned, e.g. 'opt1')",
+        },
+        ipv4: {
+          type: "string",
+          description:
+            "IPv4 address (e.g. '10.10.10.1'), or 'none' / 'dhcp'. Omit to leave IPv4 unchanged.",
+        },
+        subnet: {
+          type: ["string", "number"],
+          description: "IPv4 CIDR prefix length (0..32). Required when ipv4 is a literal address.",
+        },
+        ipv6: {
+          type: "string",
+          description:
+            "IPv6 address, or 'none' / 'dhcp6' / 'track6'. Omit to leave IPv6 unchanged.",
+        },
+        subnetv6: {
+          type: ["string", "number"],
+          description: "IPv6 CIDR prefix length (0..128). Required when ipv6 is a literal address.",
+        },
+        track6_interface: {
+          type: "string",
+          description: "Parent interface for track6 (e.g. 'wan'). Required when ipv6=track6.",
+        },
+        track6_prefix_id: {
+          type: ["string", "number"],
+          description: "Numeric prefix ID for track6 (optional)",
+        },
+        descr: {
+          type: "string",
+          description: "Optional friendly description (max 120 chars)",
+        },
+        no_filter_reload: {
+          type: "boolean",
+          description:
+            "Skip filter_configure() after applying (default false). Useful when batching multiple configures.",
+        },
+      },
+      required: ["slot"],
+    },
   },
 ];
 
@@ -104,6 +203,44 @@ export async function handleInterfacesTool(
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
+      case "opnsense_if_assign": {
+        const ssh = requireSshClient();
+        const parsed = IfAssignSchema.parse(args);
+        const cliArgs = [`--slot=${parsed.slot}`, `--if=${parsed.if}`];
+        if (parsed.descr !== undefined) {
+          cliArgs.push(`--descr=${parsed.descr}`);
+        }
+        const { response, exitCode, stderr } = await ssh.runHelper(
+          "if_assign.php",
+          cliArgs,
+        );
+        return renderHelperResult(response, exitCode, stderr);
+      }
+
+      case "opnsense_if_configure": {
+        const ssh = requireSshClient();
+        const parsed = IfConfigureSchema.parse(args);
+        const cliArgs: string[] = [`--slot=${parsed.slot}`];
+        if (parsed.ipv4 !== undefined) cliArgs.push(`--ipv4=${parsed.ipv4}`);
+        if (parsed.subnet !== undefined) cliArgs.push(`--subnet=${parsed.subnet}`);
+        if (parsed.ipv6 !== undefined) cliArgs.push(`--ipv6=${parsed.ipv6}`);
+        if (parsed.subnetv6 !== undefined) cliArgs.push(`--subnetv6=${parsed.subnetv6}`);
+        if (parsed.track6_interface !== undefined) {
+          cliArgs.push(`--track6-interface=${parsed.track6_interface}`);
+        }
+        if (parsed.track6_prefix_id !== undefined) {
+          cliArgs.push(`--track6-prefix-id=${parsed.track6_prefix_id}`);
+        }
+        if (parsed.descr !== undefined) cliArgs.push(`--descr=${parsed.descr}`);
+        if (parsed.no_filter_reload === true) cliArgs.push("--no-filter-reload");
+
+        const { response, exitCode, stderr } = await ssh.runHelper(
+          "if_configure.php",
+          cliArgs,
+        );
+        return renderHelperResult(response, exitCode, stderr);
+      }
+
       default:
         return {
           content: [{ type: "text", text: `Unknown interfaces tool: ${name}` }],
@@ -115,4 +252,56 @@ export async function handleInterfacesTool(
       content: [{ type: "text", text: `Error executing ${name}: ${message}` }],
     };
   }
+}
+
+// ---------------------------------------------------------------------------
+// SSH-backed helper wiring
+// ---------------------------------------------------------------------------
+
+/**
+ * Lazy SSH client singleton. Constructed on first use so that tests and
+ * non-SSH deployments don't pay the file-existence cost at module load.
+ */
+let sshClientInstance: SshClient | null | undefined;
+
+export function requireSshClient(): SshClient {
+  if (sshClientInstance === undefined) {
+    sshClientInstance = SshClient.fromEnv();
+  }
+  if (sshClientInstance === null) {
+    throw new Error(
+      "SSH-backed interface tools require OPNSENSE_SSH_ENABLED=true plus " +
+        "OPNSENSE_SSH_HOST / OPNSENSE_SSH_USER / OPNSENSE_SSH_KEY_PATH / " +
+        "OPNSENSE_SSH_KNOWN_HOSTS. See README 'SSH-backed interface assignment'.",
+    );
+  }
+  return sshClientInstance;
+}
+
+/** Test-only: reset the cached SSH client singleton. */
+export function _resetSshClientForTesting(): void {
+  sshClientInstance = undefined;
+}
+
+interface HelperResponseShape {
+  ok: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+function renderHelperResult(
+  response: HelperResponseShape,
+  exitCode: number,
+  stderr: string,
+): { content: Array<{ type: "text"; text: string }> } {
+  const payload: Record<string, unknown> = {
+    ...response,
+    exit_code: exitCode,
+  };
+  if (!response.ok && stderr.trim() !== "") {
+    payload.stderr_tail = stderr.trim().split("\n").slice(-3).join("\n");
+  }
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+  };
 }

--- a/tests/client/ssh-client.test.ts
+++ b/tests/client/ssh-client.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SshClient, shellQuote } from "../../src/client/ssh-client.js";
+
+describe("shellQuote", () => {
+  it("leaves safe tokens untouched", () => {
+    expect(shellQuote("opt1")).toBe("opt1");
+    expect(shellQuote("vlan10")).toBe("vlan10");
+    expect(shellQuote("--slot=opt1")).toBe("--slot=opt1");
+    expect(shellQuote("/usr/local/opnsense/scripts/mcp/if_assign.php")).toBe(
+      "/usr/local/opnsense/scripts/mcp/if_assign.php",
+    );
+  });
+
+  it("wraps values with whitespace in single quotes", () => {
+    expect(shellQuote("home VLAN")).toBe("'home VLAN'");
+    expect(shellQuote("--descr=home VLAN")).toBe("'--descr=home VLAN'");
+  });
+
+  it("escapes embedded single quotes", () => {
+    expect(shellQuote("it's fine")).toBe(`'it'\\''s fine'`);
+  });
+
+  it("quotes the empty string", () => {
+    expect(shellQuote("")).toBe("''");
+  });
+
+  it("quotes shell metacharacters", () => {
+    expect(shellQuote("a;b")).toBe("'a;b'");
+    expect(shellQuote("a|b")).toBe("'a|b'");
+    expect(shellQuote("a$(b)")).toBe("'a$(b)'");
+    expect(shellQuote("a`b`")).toBe("'a`b`'");
+  });
+});
+
+describe("SshClient", () => {
+  let tmpDir: string;
+  let keyPath: string;
+  let knownHostsPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ssh-client-test-"));
+    keyPath = join(tmpDir, "id_test");
+    knownHostsPath = join(tmpDir, "known_hosts");
+    writeFileSync(keyPath, "fake-key", { mode: 0o600 });
+    writeFileSync(knownHostsPath, "fake host key line\n");
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("constructor", () => {
+    it("throws when key file does not exist", () => {
+      expect(
+        () =>
+          new SshClient({
+            host: "h",
+            user: "u",
+            keyPath: join(tmpDir, "missing"),
+            knownHostsPath,
+          }),
+      ).toThrow(/SSH key not found/);
+    });
+
+    it("throws when known_hosts file does not exist", () => {
+      expect(
+        () =>
+          new SshClient({
+            host: "h",
+            user: "u",
+            keyPath,
+            knownHostsPath: join(tmpDir, "missing"),
+          }),
+      ).toThrow(/known_hosts file not found/);
+    });
+
+    it("accepts a valid config", () => {
+      const client = new SshClient({ host: "h", user: "u", keyPath, knownHostsPath });
+      expect(client).toBeInstanceOf(SshClient);
+    });
+  });
+
+  describe("fromEnv", () => {
+    it("returns null when OPNSENSE_SSH_ENABLED is not set", () => {
+      expect(SshClient.fromEnv()).toBeNull();
+    });
+
+    it("returns null when OPNSENSE_SSH_ENABLED is false", () => {
+      vi.stubEnv("OPNSENSE_SSH_ENABLED", "false");
+      expect(SshClient.fromEnv()).toBeNull();
+    });
+
+    it("builds a client when all required vars are set", () => {
+      vi.stubEnv("OPNSENSE_SSH_ENABLED", "true");
+      vi.stubEnv("OPNSENSE_SSH_HOST", "fw.example.com");
+      vi.stubEnv("OPNSENSE_SSH_USER", "claude");
+      vi.stubEnv("OPNSENSE_SSH_KEY_PATH", keyPath);
+      vi.stubEnv("OPNSENSE_SSH_KNOWN_HOSTS", knownHostsPath);
+      const client = SshClient.fromEnv();
+      expect(client).toBeInstanceOf(SshClient);
+    });
+
+    it("throws when OPNSENSE_SSH_HOST is missing", () => {
+      vi.stubEnv("OPNSENSE_SSH_ENABLED", "true");
+      vi.stubEnv("OPNSENSE_SSH_USER", "claude");
+      vi.stubEnv("OPNSENSE_SSH_KEY_PATH", keyPath);
+      vi.stubEnv("OPNSENSE_SSH_KNOWN_HOSTS", knownHostsPath);
+      expect(() => SshClient.fromEnv()).toThrow(/OPNSENSE_SSH_HOST/);
+    });
+
+    it("throws when the key file does not exist", () => {
+      vi.stubEnv("OPNSENSE_SSH_ENABLED", "true");
+      vi.stubEnv("OPNSENSE_SSH_HOST", "fw.example.com");
+      vi.stubEnv("OPNSENSE_SSH_USER", "claude");
+      vi.stubEnv("OPNSENSE_SSH_KEY_PATH", join(tmpDir, "missing"));
+      vi.stubEnv("OPNSENSE_SSH_KNOWN_HOSTS", knownHostsPath);
+      expect(() => SshClient.fromEnv()).toThrow(/SSH key not found/);
+    });
+  });
+
+  describe("buildSshArgv", () => {
+    it("assembles argv with strict host key checking and batch mode", () => {
+      const client = new SshClient({
+        host: "fw.example.com",
+        user: "claude",
+        keyPath,
+        knownHostsPath,
+      });
+      const argv = client.buildSshArgv("whoami");
+      expect(argv).toEqual([
+        "-i",
+        keyPath,
+        "-o",
+        `UserKnownHostsFile=${knownHostsPath}`,
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "PreferredAuthentications=publickey",
+        "-o",
+        "ConnectTimeout=10",
+        "claude@fw.example.com",
+        "whoami",
+      ]);
+    });
+
+    it("includes custom port when configured", () => {
+      const client = new SshClient({
+        host: "fw.example.com",
+        user: "claude",
+        keyPath,
+        knownHostsPath,
+        port: 2222,
+      });
+      const argv = client.buildSshArgv("whoami");
+      expect(argv).toContain("-p");
+      expect(argv).toContain("2222");
+    });
+  });
+
+  describe("buildHelperCommand", () => {
+    let client: SshClient;
+    beforeEach(() => {
+      client = new SshClient({ host: "h", user: "u", keyPath, knownHostsPath });
+    });
+
+    it("inserts the mandatory -- separator (ADR-0092)", () => {
+      const cmd = client.buildHelperCommand("if_assign.php", [
+        "--slot=opt1",
+        "--if=vlan10",
+      ]);
+      expect(cmd).toBe(
+        "sudo php -f /usr/local/opnsense/scripts/mcp/if_assign.php -- --slot=opt1 --if=vlan10",
+      );
+    });
+
+    it("quotes args containing whitespace", () => {
+      const cmd = client.buildHelperCommand("if_assign.php", [
+        "--slot=opt1",
+        "--if=vlan10",
+        "--descr=home VLAN",
+      ]);
+      expect(cmd).toBe(
+        "sudo php -f /usr/local/opnsense/scripts/mcp/if_assign.php -- --slot=opt1 --if=vlan10 '--descr=home VLAN'",
+      );
+    });
+
+    it("honors a custom helperDir", () => {
+      const client2 = new SshClient({
+        host: "h",
+        user: "u",
+        keyPath,
+        knownHostsPath,
+        helperDir: "/opt/custom",
+      });
+      const cmd = client2.buildHelperCommand("if_assign.php", ["--slot=opt1"]);
+      expect(cmd).toBe("sudo php -f /opt/custom/if_assign.php -- --slot=opt1");
+    });
+
+    it("refuses to let a shell metacharacter break out", () => {
+      const cmd = client.buildHelperCommand("if_assign.php", [
+        "--slot=opt1",
+        "--if=vlan10; rm -rf /",
+      ]);
+      // The malicious value is wrapped in single quotes
+      expect(cmd).toContain(`'--if=vlan10; rm -rf /'`);
+      // And there is no unquoted `;` outside the quoted region
+      const beforeQuoted = cmd.split("'--if=vlan10; rm -rf /'")[0];
+      expect(beforeQuoted).not.toContain(";");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- New `src/client/ssh-client.ts` — minimal SSH client backed by the system `ssh` binary via `spawn()` (no new runtime dependencies, stays within the axios + zod + sdk budget)
- New tools `opnsense_if_assign` and `opnsense_if_configure` wire mcp-opnsense to the PHP helpers shipped in v2026.04.09.4
- Closes the long-standing gap where the OPNsense REST API has no "Interfaces → Assignments" endpoint

## Security

- Strict host key checking enforced via required `OPNSENSE_SSH_KNOWN_HOSTS` file — no TOFU fallback
- `BatchMode=yes` + `PreferredAuthentications=publickey` disables password/keyboard-interactive auth
- Arguments are single-quote-escaped before concatenation into the remote command string — no argv breakout from untrusted tool input
- PHP `--` separator inserted automatically (mandatory per ADR-0092 spike)
- Both tools fail fast with a clear error if `OPNSENSE_SSH_ENABLED` is not `true`; non-SSH deployments are unaffected

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 120/120 passing (19 new)
- [x] Shell-quote edge cases (`;`, `|`, `` ` ``, `$()`, embedded single quotes, empty string)
- [x] SSH argv assembly (strict host key checking, batch mode, custom port)
- [x] Helper command assembly with the mandatory `--` separator
- [x] `fromEnv()` env-var requirements + file existence checks
- [ ] End-to-end against a real OPNsense host — will be exercised in #374 Phase 1 execution under a fresh sys_backup snapshot

## Closes

- #97

## Related

- v2026.04.09.4 (server-side helpers) / #95
- ADR-0092 (private infra repo)