### PR TITLE
fix: kea subnet create/update payload missing subnet4 wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.04.10.1
+
+- **Fix `opnsense_kea_subnet_create` and `opnsense_kea_subnet_update` silent failure** (#101)
+  - POST payload was using `{ subnet: {...} }` instead of `{ subnet4: {...} }` wrapper
+  - OPNsense Kea DHCPv4 API requires `subnet4` as the top-level key for subnet operations
+  - Both `keaAddSubnet` and `keaUpdateSubnet` now correctly wrap the payload
+
 ## v2026.04.09.5
 
 - **Add `opnsense_if_assign` and `opnsense_if_configure` SSH-backed tools** (#97)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified/mcp-opnsense",
-  "version": "2026.4.9-5",
+  "version": "2026.4.10-1",
   "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/dhcp.ts
+++ b/src/tools/dhcp.ts
@@ -311,7 +311,7 @@ async function keaAddSubnet(
   if (parsed.domain_search) subnet.option_domain_search = parsed.domain_search;
   if (parsed.ntp_servers) subnet.option_ntp_servers = parsed.ntp_servers;
 
-  const result = await client.post("/kea/dhcpv4/add_subnet", { subnet });
+  const result = await client.post("/kea/dhcpv4/add_subnet", { subnet4: subnet });
   return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
 }
 
@@ -331,7 +331,7 @@ async function keaUpdateSubnet(
   if (parsed.domain_search !== undefined) subnet.option_domain_search = parsed.domain_search;
   if (parsed.ntp_servers !== undefined) subnet.option_ntp_servers = parsed.ntp_servers;
 
-  const result = await client.post(`/kea/dhcpv4/set_subnet/${parsed.uuid}`, { subnet });
+  const result = await client.post(`/kea/dhcpv4/set_subnet/${parsed.uuid}`, { subnet4: subnet });
   return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
 }
 


### PR DESCRIPTION
## Summary
- Fix `opnsense_kea_subnet_create` and `opnsense_kea_subnet_update` silent failure
- POST payload was using `{ subnet: {...} }` instead of `{ subnet4: {...} }` wrapper
- OPNsense Kea DHCPv4 API requires `subnet4` as the top-level key

Closes #101

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` — 120 tests pass
- [x] Verified correct wrapper key against OPNsense Kea API docs and working curl commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)