### PR TITLE
fix: correct npm scope from @itunified to @itunified.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.04.10.3
+
+- **Fix npm scope from `@itunified` to `@itunified.io`** (#105)
+  - Corrects package name to match the npm org `@itunified.io` (with dot)
+  - First npm publish under `@itunified.io/mcp-opnsense`
+
 ## v2026.04.10.2
 
 - **Add `opnsense_tailscale_*` tool family for os-tailscale plugin API** (#103)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@itunified/mcp-opnsense",
-  "version": "2026.4.10-2",
+  "name": "@itunified.io/mcp-opnsense",
+  "version": "2026.4.10-3",
   "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ for (const def of vlanToolDefinitions) toolHandlers.set(def.name, handleVlanTool
 for (const def of tailscaleToolDefinitions) toolHandlers.set(def.name, handleTailscaleTool);
 
 const server = new Server(
-  { name: 'mcp-opnsense', version: '2026.4.9-5' },
+  { name: 'mcp-opnsense', version: '2026.4.10-3' },
   { capabilities: { tools: {} } }
 );
 


### PR DESCRIPTION
## Summary
- Fixes npm package scope from `@itunified/mcp-opnsense` to `@itunified.io/mcp-opnsense`
- Bumps version to `2026.4.10-3` for first npm publish under correct scope

Closes #105

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (120/120)
- [ ] `npm publish --access public` succeeds under `@itunified.io` scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)