### PR TITLE
fix: opnsense_fw_reorder_rules fails on setRule payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.04.10.5
+
+- **fix: opnsense_fw_reorder_rules fails with 'Unexpected error' on setRule** (#108)
+  - Root cause: getRule returns multi-select fields as nested `{key: {selected: 0|1}}` objects, but the generic flattener didn't handle all field types (source_net, gateway, categories, etc.)
+  - Fix: replace generic roundtrip with clean payload extraction — only send the core fields setRule accepts (enabled, action, direction, interface, ipprotocol, protocol, source/dest net/not/port, log, description, sequence)
+  - New `extractSelected()` helper exported for multi-select field parsing
+  - 14 new unit tests (9 extractSelected + 3 reorder + 2 tool definitions)
+
 ## v2026.04.10.4
 
 - **Add MCP Registry listing** — `server.json` + `mcpName` for `registry.modelcontextprotocol.io`

--- a/src/tools/firewall.ts
+++ b/src/tools/firewall.ts
@@ -261,6 +261,43 @@ export const firewallToolDefinitions = [
 ];
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the selected key from an OPNsense multi-select field.
+ *
+ * getRule returns multi-select fields as:
+ *   { "pass": { "value": "Pass", "selected": 1 }, "block": { "value": "Block", "selected": 0 } }
+ *
+ * setRule expects the flat key string, e.g. "pass".
+ *
+ * Handles both numeric (selected: 1) and string (selected: "1") variants.
+ * Returns undefined if the field is not a recognized multi-select object.
+ */
+export function extractSelected(field: unknown): string | undefined {
+  if (typeof field === "string") return field;
+  if (field && typeof field === "object" && !Array.isArray(field)) {
+    const entries = Object.entries(field as Record<string, unknown>);
+    const selected: string[] = [];
+    for (const [k, v] of entries) {
+      if (
+        v &&
+        typeof v === "object" &&
+        ((v as Record<string, unknown>).selected === 1 ||
+          (v as Record<string, unknown>).selected === "1")
+      ) {
+        selected.push(k);
+      }
+    }
+    if (selected.length > 0) return selected.join(",");
+    // Not a multi-select object (no {selected} children) — return undefined
+    return undefined;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
 // Tool handler
 // ---------------------------------------------------------------------------
 
@@ -377,8 +414,14 @@ export async function handleFirewallTool(
       case "opnsense_fw_reorder_rules": {
         const parsed = ReorderRuleSchema.parse(args);
         // OPNsense core filter rules carry a `sequence` field that controls
-        // evaluation order. Update it via setRule, merging with the existing
-        // rule body so we don't wipe other fields.
+        // evaluation order. Read the existing rule, extract the core fields
+        // that setRule accepts, and POST back with the new sequence.
+        //
+        // Why not roundtrip the full getRule response? Because getRule returns
+        // multi-select fields as {key: {value, selected}} objects while setRule
+        // expects flat strings. The generic flattening approach is fragile — some
+        // fields (source_net, log, gateway, etc.) have structures the flattener
+        // doesn't handle. Instead, extract only the known core fields.
         const existing = await client.get<{ rule?: Record<string, unknown> }>(
           `/firewall/filter/getRule/${parsed.uuid}`,
         );
@@ -390,31 +433,28 @@ export async function handleFirewallTool(
           };
         }
 
-        // OPNsense returns multi-select fields as {value: {selected: 0|1}} objects
-        // on getRule but expects comma-joined strings on setRule. Flatten.
-        const flattened: Record<string, unknown> = {};
-        for (const [key, value] of Object.entries(existing.rule)) {
-          if (value && typeof value === "object" && !Array.isArray(value)) {
-            const selected: string[] = [];
-            for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-              if (
-                v &&
-                typeof v === "object" &&
-                (v as { selected?: number }).selected === 1
-              ) {
-                selected.push(k);
-              }
-            }
-            flattened[key] = selected.join(",");
-          } else {
-            flattened[key] = value;
-          }
-        }
-        flattened["sequence"] = String(parsed.sequence);
-
+        const r = existing.rule;
         const result = await client.post(
           `/firewall/filter/setRule/${parsed.uuid}`,
-          { rule: flattened },
+          {
+            rule: {
+              enabled: extractSelected(r["enabled"]) ?? "1",
+              action: extractSelected(r["action"]) ?? "pass",
+              direction: extractSelected(r["direction"]) ?? "in",
+              interface: extractSelected(r["interface"]) ?? "",
+              ipprotocol: extractSelected(r["ipprotocol"]) ?? "inet",
+              protocol: extractSelected(r["protocol"]) ?? "any",
+              source_net: typeof r["source_net"] === "string" ? r["source_net"] : "any",
+              source_not: extractSelected(r["source_not"]) ?? "0",
+              source_port: typeof r["source_port"] === "string" ? r["source_port"] : "",
+              destination_net: typeof r["destination_net"] === "string" ? r["destination_net"] : "any",
+              destination_not: extractSelected(r["destination_not"]) ?? "0",
+              destination_port: typeof r["destination_port"] === "string" ? r["destination_port"] : "",
+              log: extractSelected(r["log"]) ?? "0",
+              description: typeof r["description"] === "string" ? r["description"] : "",
+              sequence: String(parsed.sequence),
+            },
+          },
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }

--- a/tests/tools/firewall.test.ts
+++ b/tests/tools/firewall.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  firewallToolDefinitions,
+  handleFirewallTool,
+  extractSelected,
+} from "../../src/tools/firewall.js";
+import type { OPNsenseClient } from "../../src/client/opnsense-client.js";
+
+function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
+  return {
+    get: vi.fn().mockResolvedValue({ rows: [] }),
+    post: vi.fn().mockResolvedValue({ result: "saved" }),
+    delete: vi.fn().mockResolvedValue({ status: "ok" }),
+    ...overrides,
+  } as unknown as OPNsenseClient;
+}
+
+// ---------------------------------------------------------------------------
+// extractSelected helper
+// ---------------------------------------------------------------------------
+
+describe("extractSelected", () => {
+  it("returns string values as-is", () => {
+    expect(extractSelected("pass")).toBe("pass");
+    expect(extractSelected("1")).toBe("1");
+    expect(extractSelected("")).toBe("");
+  });
+
+  it("extracts selected key from multi-select with numeric selected", () => {
+    const field = {
+      pass: { value: "Pass", selected: 1 },
+      block: { value: "Block", selected: 0 },
+      reject: { value: "Reject", selected: 0 },
+    };
+    expect(extractSelected(field)).toBe("pass");
+  });
+
+  it("extracts selected key from multi-select with string selected", () => {
+    const field = {
+      in: { value: "In", selected: "1" },
+      out: { value: "Out", selected: "0" },
+    };
+    expect(extractSelected(field)).toBe("in");
+  });
+
+  it("returns comma-joined keys when multiple are selected", () => {
+    const field = {
+      lan: { value: "LAN", selected: 1 },
+      wan: { value: "WAN", selected: 1 },
+      opt1: { value: "OPT1", selected: 0 },
+    };
+    expect(extractSelected(field)).toBe("lan,wan");
+  });
+
+  it("returns undefined for non-multi-select objects", () => {
+    // An object without {selected} children
+    const field = { some: "value", other: 42 };
+    expect(extractSelected(field)).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(extractSelected(null)).toBeUndefined();
+  });
+
+  it("returns undefined for undefined", () => {
+    expect(extractSelected(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for numbers", () => {
+    expect(extractSelected(42)).toBeUndefined();
+  });
+
+  it("returns undefined for arrays", () => {
+    expect(extractSelected(["a", "b"])).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+describe("firewallToolDefinitions", () => {
+  it("all tools have opnsense_fw_ prefix", () => {
+    for (const tool of firewallToolDefinitions) {
+      expect(tool.name).toMatch(/^opnsense_fw_/);
+    }
+  });
+
+  it("all tools have descriptions", () => {
+    for (const tool of firewallToolDefinitions) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description.length).toBeGreaterThan(10);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// opnsense_fw_reorder_rules
+// ---------------------------------------------------------------------------
+
+describe("handleFirewallTool — opnsense_fw_reorder_rules", () => {
+  it("extracts core fields from getRule and sends clean setRule payload", async () => {
+    const getResponse = {
+      rule: {
+        enabled: {
+          "1": { value: "Enabled", selected: 1 },
+          "0": { value: "Disabled", selected: 0 },
+        },
+        action: {
+          pass: { value: "Pass", selected: 0 },
+          block: { value: "Block", selected: 1 },
+          reject: { value: "Reject", selected: 0 },
+        },
+        direction: {
+          in: { value: "In", selected: 1 },
+          out: { value: "Out", selected: 0 },
+        },
+        interface: {
+          lan: { value: "LAN", selected: 1 },
+          wan: { value: "WAN", selected: 0 },
+        },
+        ipprotocol: {
+          inet: { value: "IPv4", selected: 1 },
+          inet6: { value: "IPv6", selected: 0 },
+        },
+        protocol: {
+          any: { value: "any", selected: 1 },
+          TCP: { value: "TCP", selected: 0 },
+        },
+        source_net: "zone_iot",
+        source_not: {
+          "0": { value: "No", selected: 1 },
+          "1": { value: "Yes", selected: 0 },
+        },
+        source_port: "",
+        destination_net: "10.10.0.0/24",
+        destination_not: {
+          "0": { value: "No", selected: 1 },
+          "1": { value: "Yes", selected: 0 },
+        },
+        destination_port: "",
+        log: {
+          "0": { value: "No", selected: 1 },
+          "1": { value: "Yes", selected: 0 },
+        },
+        description: "IoT → LAN blocked (isolation)",
+        sequence: "1",
+        // Extra fields that getRule returns but setRule should NOT receive:
+        gateway: { "": { value: "default", selected: 1 } },
+        categories: {},
+        quick: { "1": { value: "Yes", selected: 1 } },
+      },
+    };
+
+    const postFn = vi.fn().mockResolvedValue({ result: "saved" });
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue(getResponse),
+      post: postFn,
+    });
+
+    const result = await handleFirewallTool(
+      "opnsense_fw_reorder_rules",
+      { uuid: "adc89225-6b44-467b-87c8-54702132b2f1", sequence: 5 },
+      client,
+    );
+
+    expect(result.content[0].text).toContain("saved");
+
+    // Verify the POST payload has clean, flat values
+    const postCall = postFn.mock.calls[0];
+    expect(postCall[0]).toBe(
+      "/firewall/filter/setRule/adc89225-6b44-467b-87c8-54702132b2f1",
+    );
+    const payload = postCall[1].rule;
+    expect(payload.enabled).toBe("1");
+    expect(payload.action).toBe("block");
+    expect(payload.direction).toBe("in");
+    expect(payload.interface).toBe("lan");
+    expect(payload.ipprotocol).toBe("inet");
+    expect(payload.protocol).toBe("any");
+    expect(payload.source_net).toBe("zone_iot");
+    expect(payload.source_not).toBe("0");
+    expect(payload.destination_net).toBe("10.10.0.0/24");
+    expect(payload.destination_not).toBe("0");
+    expect(payload.log).toBe("0");
+    expect(payload.description).toBe("IoT → LAN blocked (isolation)");
+    expect(payload.sequence).toBe("5");
+
+    // Verify extra fields (gateway, categories, quick) are NOT sent
+    expect(payload.gateway).toBeUndefined();
+    expect(payload.categories).toBeUndefined();
+    expect(payload.quick).toBeUndefined();
+  });
+
+  it("returns not-found message for missing rule", async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({ rule: null }),
+    });
+
+    const result = await handleFirewallTool(
+      "opnsense_fw_reorder_rules",
+      { uuid: "00000000-0000-0000-0000-000000000000", sequence: 5 },
+      client,
+    );
+
+    expect(result.content[0].text).toContain("not found");
+  });
+
+  it("uses defaults when getRule fields are missing", async () => {
+    const postFn = vi.fn().mockResolvedValue({ result: "saved" });
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({ rule: {} }),
+      post: postFn,
+    });
+
+    await handleFirewallTool(
+      "opnsense_fw_reorder_rules",
+      { uuid: "11111111-1111-1111-1111-111111111111", sequence: 10 },
+      client,
+    );
+
+    const payload = postFn.mock.calls[0][1].rule;
+    expect(payload.enabled).toBe("1");
+    expect(payload.action).toBe("pass");
+    expect(payload.direction).toBe("in");
+    expect(payload.protocol).toBe("any");
+    expect(payload.source_net).toBe("any");
+    expect(payload.destination_net).toBe("any");
+    expect(payload.sequence).toBe("10");
+  });
+});


### PR DESCRIPTION
## Summary

- Root cause: `reorder_rules` roundtripped the full `getRule` response through a generic flattener, but OPNsense returns fields (`gateway`, `categories`, `quick`, etc.) that don't follow the multi-select `{key: {selected: 0|1}}` pattern, causing `setRule` to reject the payload
- Fix: extract only the core fields that `setRule` accepts (same field set as `addRule`/`updateRule`), plus `sequence`
- New exported `extractSelected()` helper handles multi-select fields with both numeric (`selected: 1`) and string (`selected: "1"`) variants
- 14 new unit tests: 9 for `extractSelected`, 3 for reorder scenarios, 2 for tool definitions

Closes #108

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` — 134 tests pass (14 new + 120 existing)
- [ ] Live test: `opnsense_fw_reorder_rules` on bifrost

🤖 Generated with [Claude Code](https://claude.com/claude-code)