### PR TITLE
fix: log + fw_logs limit Zod validation (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.04.29.3
+
+- **fix: log + fw_logs `limit` param fails Zod validation** (#116)
+  - MCP transport serializes numeric params as strings; `z.number()` rejects them
+  - Replaced `z.number()` → `z.coerce.number()` in `LogQuerySchema` (4 log tools) and `FwLogsSchema` (`diag_fw_logs`)
+  - Same root cause as the mcp-cloudflare `proxied` boolean bug
+  - 1 new test (152 total, all green)
+
 ## v2026.04.29.2
 
 - **feat: add system log + gateway status tools** (#113)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified.io/mcp-opnsense",
-  "version": "2026.4.29-2",
+  "version": "2026.4.29-3",
   "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -24,12 +24,14 @@ const DnsLookupSchema = z.object({
   hostname: z.string().min(1, "Hostname or IP address is required"),
 });
 
+// Use z.coerce.number() because MCP transports serialize numeric tool params as
+// strings — see #116 (mirror of mcp-cloudflare proxied boolean bug).
 const FwLogsSchema = z.object({
-  limit: z.number().int().min(1).max(5000).optional().default(50),
+  limit: z.coerce.number().int().min(1).max(5000).optional().default(50),
 });
 
 const LogQuerySchema = z.object({
-  limit: z.number().int().min(1).max(5000).optional().default(500),
+  limit: z.coerce.number().int().min(1).max(5000).optional().default(500),
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/tools/diagnostics-logs.test.ts
+++ b/tests/tools/diagnostics-logs.test.ts
@@ -66,6 +66,12 @@ describe('handleDiagnosticsTool — log endpoints', () => {
     expect(client.get).not.toHaveBeenCalled();
   });
 
+  it('coerces string limit to number (MCP transport sends numbers as strings)', async () => {
+    const client = mockClient();
+    await handleDiagnosticsTool('opnsense_diag_log_gateways', { limit: '100' as unknown as number }, client);
+    expect(client.get).toHaveBeenCalledWith('/diagnostics/log/core/gateways?limit=100');
+  });
+
   it('handles API errors gracefully', async () => {
     const client = mockClient({
       get: vi.fn().mockRejectedValue(new Error('502 Bad Gateway')),


### PR DESCRIPTION
Closes #116. `z.number()` → `z.coerce.number()` for MCP-string-as-number params. 152/152 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)