### PR TITLE
feat: add opnsense_firmware_check (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.04.29.4
+
+- **feat: add opnsense_firmware_check** (#118)
+  - POST `/core/firmware/check` to refresh cached repo state
+  - Required before `firmware_status` after cache TTL expires
+  - 1 new test (153 total green)
+
 ## v2026.04.29.3
 
 - **fix: log + fw_logs `limit` param fails Zod validation** (#116)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified.io/mcp-opnsense",
-  "version": "2026.4.29-3",
+  "version": "2026.4.29-4",
   "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/firmware.ts
+++ b/src/tools/firmware.ts
@@ -42,7 +42,13 @@ export const firmwareToolDefinitions = [
   {
     name: "opnsense_firmware_status",
     description:
-      "Check for available firmware upgrades and their status (running, pending, done)",
+      "Check for available firmware upgrades and their status (running, pending, done). Reads the cached state — call 'opnsense_firmware_check' first if the cache may be stale.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_firmware_check",
+    description:
+      "Trigger a background firmware repository check to refresh the cached upgrade status. After calling this, wait briefly and then call 'opnsense_firmware_status' to see fresh upgrade info.",
     inputSchema: { type: "object" as const, properties: {} },
   },
   {
@@ -144,6 +150,11 @@ export async function handleFirmwareTool(
 
       case "opnsense_firmware_status": {
         const result = await client.get("/core/firmware/status");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_firmware_check": {
+        const result = await client.post("/core/firmware/check");
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 

--- a/tests/tools/firmware.test.ts
+++ b/tests/tools/firmware.test.ts
@@ -12,8 +12,8 @@ function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
 }
 
 describe('Firmware Tool Definitions', () => {
-  it('exports 8 tool definitions', () => {
-    expect(firmwareToolDefinitions).toHaveLength(8);
+  it('exports 9 tool definitions', () => {
+    expect(firmwareToolDefinitions).toHaveLength(9);
   });
 
   it('all tools have opnsense_firmware_ prefix', () => {
@@ -125,6 +125,15 @@ describe('handleFirmwareTool', () => {
     const client = mockClient();
     const result = await handleFirmwareTool('opnsense_firmware_nonexistent', {}, client);
     expect(result.content[0].text).toContain('Unknown');
+  });
+
+  it('triggers a firmware check (refresh repo)', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ status: 'ok' }),
+    });
+    const result = await handleFirmwareTool('opnsense_firmware_check', {}, client);
+    expect(result.content[0].text).toContain('ok');
+    expect(client.post).toHaveBeenCalledWith('/core/firmware/check');
   });
 
   it('triggers a system upgrade with confirmation', async () => {


### PR DESCRIPTION
Closes #118. POST /core/firmware/check to refresh cached repo state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)