### PR TITLE
fix: confirm bool coerce (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.04.29.5
+
+- **fix: confirm parameter rejects boolean true (MCP sends as string)** (#120)
+  - Same transport bug pattern as #116 (number coerce); booleans also serialized as strings by MCP
+  - New `ConfirmTrue()` helper using `z.preprocess` to coerce `"true"`/`"false"` strings to booleans before literal check
+  - Affects: `firmware_upgrade`, `firmware_reboot`, `firmware_remove`
+  - 3 new tests (156 total green)
+
 ## v2026.04.29.4
 
 - **feat: add opnsense_firmware_check** (#118)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified.io/mcp-opnsense",
-  "version": "2026.4.29-4",
+  "version": "2026.4.29-5",
   "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/firmware.ts
+++ b/src/tools/firmware.ts
@@ -9,23 +9,25 @@ const PackageSchema = z.object({
   package: z.string().min(1, "Package name is required"),
 });
 
+// MCP transports may serialize booleans as strings — coerce "true" → true
+// before the literal check (same root cause as #116 for numbers).
+const ConfirmTrue = (msg: string) =>
+  z.preprocess(
+    (v) => (v === "true" ? true : v === "false" ? false : v),
+    z.literal(true, { errorMap: () => ({ message: msg }) }),
+  );
+
 const RemovePackageSchema = z.object({
   package: z.string().min(1, "Package name is required"),
-  confirm: z.literal(true, {
-    errorMap: () => ({ message: "confirm must be true to proceed with package removal" }),
-  }),
+  confirm: ConfirmTrue("confirm must be true to proceed with package removal"),
 });
 
 const UpgradeSchema = z.object({
-  confirm: z.literal(true, {
-    errorMap: () => ({ message: "confirm must be true to proceed with the system upgrade" }),
-  }),
+  confirm: ConfirmTrue("confirm must be true to proceed with the system upgrade"),
 });
 
 const RebootSchema = z.object({
-  confirm: z.literal(true, {
-    errorMap: () => ({ message: "confirm must be true to proceed with the reboot" }),
-  }),
+  confirm: ConfirmTrue("confirm must be true to proceed with the reboot"),
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/tools/firmware.test.ts
+++ b/tests/tools/firmware.test.ts
@@ -147,6 +147,44 @@ describe('handleFirmwareTool', () => {
     expect(client.post).toHaveBeenCalledWith('/core/firmware/upgrade');
   });
 
+  it('coerces string "true" to true on upgrade confirm (MCP transport)', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ status: 'ok', msg_uuid: 'abc-123' }),
+    });
+    const result = await handleFirmwareTool(
+      'opnsense_firmware_upgrade',
+      { confirm: 'true' as unknown as true },
+      client,
+    );
+    expect(result.content[0].text).toContain('ok');
+    expect(client.post).toHaveBeenCalledWith('/core/firmware/upgrade');
+  });
+
+  it('coerces string "true" to true on reboot confirm', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ status: 'ok' }),
+    });
+    const result = await handleFirmwareTool(
+      'opnsense_firmware_reboot',
+      { confirm: 'true' as unknown as true },
+      client,
+    );
+    expect(result.content[0].text).toContain('ok');
+    expect(client.post).toHaveBeenCalledWith('/core/firmware/reboot');
+  });
+
+  it('coerces string "true" to true on remove confirm', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ status: 'ok' }),
+    });
+    const result = await handleFirmwareTool(
+      'opnsense_firmware_remove',
+      { package: 'os-acme-client', confirm: 'true' as unknown as true },
+      client,
+    );
+    expect(client.post).toHaveBeenCalledWith('/core/firmware/remove/os-acme-client');
+  });
+
   it('rejects upgrade without confirmation', async () => {
     const client = mockClient();
     const result = await handleFirmwareTool('opnsense_firmware_upgrade', { confirm: false }, client);


### PR DESCRIPTION
Closes #120. Same MCP string-serialization bug as #116 but for booleans. `z.preprocess` to coerce "true"/"false" before `z.literal(true)`. 156/156 tests green.