### PR TITLE
feat: opnsense_route_gateway_update + _apply (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.05.02.1
+
+- **feat: add opnsense_route_gateway_update + _apply** (#115)
+  - `opnsense_route_gateway_update` (POST `/routing/settings/setGateway/{uuid}`) — round-trips current gateway config and overrides only explicitly provided fields. Supports `monitor_disable`, `monitor`, `disabled`, `defaultgw`, `description`, `weight`, `priority`. Uses `extractSelected()` to flatten OPNsense multi-select objects. Requires `confirm: true`.
+  - `opnsense_route_gateway_apply` (POST `/routing/settings/reconfigure`) — activates pending gateway changes. Requires `confirm: true`.
+  - New shared helpers in `routing.ts`: `ConfirmTrue()` for boolean coerce on confirm, `CoerceBoolean` for "0"/"1"/"true"/"false" inputs, `boolToFlag()` for output.
+  - 6 new tests (162 total green)
+  - Verified live against OPNsense 25.1 "Ultimate Unicorn"
+
 ## v2026.04.29.5
 
 - **fix: confirm parameter rejects boolean true (MCP sends as string)** (#120)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified.io/mcp-opnsense",
-  "version": "2026.4.29-5",
+  "version": "2026.5.2-1",
   "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/routing.ts
+++ b/src/tools/routing.ts
@@ -1,6 +1,22 @@
 import { z } from "zod";
 import type { OPNsenseClient } from "../client/opnsense-client.js";
 import { UuidSchema } from "../utils/validation.js";
+import { extractSelected } from "./firewall.js";
+
+// MCP transports may serialize booleans as strings — coerce "true"/"false"
+// before the literal check (see #120).
+const ConfirmTrue = (msg: string) =>
+  z.preprocess(
+    (v) => (v === "true" ? true : v === "false" ? false : v),
+    z.literal(true, { errorMap: () => ({ message: msg }) }),
+  );
+
+// Coerce booleans that may arrive as MCP-string from clients.
+const CoerceBoolean = z.preprocess((v) => {
+  if (v === "true" || v === "1" || v === 1) return true;
+  if (v === "false" || v === "0" || v === 0) return false;
+  return v;
+}, z.boolean());
 
 // ---------------------------------------------------------------------------
 // Zod schemas for input validation
@@ -31,6 +47,29 @@ const UpdateRouteSchema = z.object({
 const DeleteRouteSchema = z.object({
   uuid: UuidSchema,
 });
+
+const GatewayUpdateSchema = z.object({
+  uuid: UuidSchema,
+  monitor_disable: CoerceBoolean.optional(),
+  monitor: z.string().optional(),
+  disabled: CoerceBoolean.optional(),
+  defaultgw: CoerceBoolean.optional(),
+  description: z.string().optional(),
+  weight: z.coerce.number().int().min(1).max(30).optional(),
+  priority: z.coerce.number().int().min(1).max(255).optional(),
+  confirm: ConfirmTrue("confirm must be true to proceed with the gateway update"),
+});
+
+const GatewayApplySchema = z.object({
+  confirm: ConfirmTrue("confirm must be true to apply gateway configuration"),
+});
+
+// Convert a JS boolean (true/false) or pass-through string ("0"/"1") to OPNsense's
+// expected "0" / "1" string representation.
+function boolToFlag(v: boolean | undefined): string | undefined {
+  if (v === undefined) return undefined;
+  return v ? "1" : "0";
+}
 
 // ---------------------------------------------------------------------------
 // Tool definitions (for ListTools)
@@ -110,6 +149,36 @@ export const routingToolDefinitions = [
     description: "Get live gateway monitor status: per-gateway online/offline state, RTT (delay), packet loss, stddev, monitor IP, and monitor_disable flag. Read-only — complements opnsense_route_gateway_list (which only returns config).",
     inputSchema: { type: "object" as const, properties: {} },
   },
+  {
+    name: "opnsense_route_gateway_update",
+    description: "Update an existing gateway's settings (toggle monitoring, set monitor IP, change weight/priority, enable/disable). Round-trips current config and only overrides explicitly provided fields. After updating, call opnsense_route_gateway_apply to activate the change. DESTRUCTIVE: requires explicit confirmation.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "Gateway UUID (from opnsense_route_gateway_list)" },
+        monitor_disable: { type: "boolean", description: "Disable gateway monitoring (true = no health probe)" },
+        monitor: { type: "string", description: "Monitor IP address (used when monitor_disable=false). Empty string clears it." },
+        disabled: { type: "boolean", description: "Disable the gateway entirely" },
+        defaultgw: { type: "boolean", description: "Mark as default gateway" },
+        description: { type: "string", description: "Human-readable description" },
+        weight: { type: "number", description: "Load-balancing weight (1-30)" },
+        priority: { type: "number", description: "Failover priority (1-255, lower = higher priority)" },
+        confirm: { type: "boolean", description: "Must be true to confirm the update", enum: [true] },
+      },
+      required: ["uuid", "confirm"],
+    },
+  },
+  {
+    name: "opnsense_route_gateway_apply",
+    description: "Apply pending gateway configuration changes (calls /api/routing/settings/reconfigure). Required after opnsense_route_gateway_update for changes to take effect. May briefly affect WAN connectivity. DESTRUCTIVE: requires explicit confirmation.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        confirm: { type: "boolean", description: "Must be true to confirm the apply", enum: [true] },
+      },
+      required: ["confirm"],
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -181,6 +250,68 @@ export async function handleRoutingTool(
 
       case "opnsense_route_gateway_status": {
         const result = await client.get("/routes/gateway/status");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_route_gateway_update": {
+        const parsed = GatewayUpdateSchema.parse(args);
+
+        // Round-trip: get current state, flatten multi-selects, override only provided fields
+        const current = (await client.get<{ gateway_item?: Record<string, unknown> }>(
+          `/routing/settings/getGateway/${encodeURIComponent(parsed.uuid)}`,
+        ))?.gateway_item ?? {};
+
+        const flat: Record<string, unknown> = {
+          name: extractSelected(current["name"]) ?? current["name"],
+          descr: parsed.description ?? (extractSelected(current["descr"]) ?? current["descr"] ?? ""),
+          interface: extractSelected(current["interface"]) ?? "",
+          ipprotocol: extractSelected(current["ipprotocol"]) ?? "inet",
+          gateway: extractSelected(current["gateway"]) ?? current["gateway"] ?? "",
+          defaultgw:
+            boolToFlag(parsed.defaultgw) ??
+            (extractSelected(current["defaultgw"]) ?? current["defaultgw"] ?? "0"),
+          fargw: extractSelected(current["fargw"]) ?? current["fargw"] ?? "",
+          monitor_disable:
+            boolToFlag(parsed.monitor_disable) ??
+            (extractSelected(current["monitor_disable"]) ?? current["monitor_disable"] ?? "0"),
+          monitor_noroute:
+            extractSelected(current["monitor_noroute"]) ?? current["monitor_noroute"] ?? "",
+          monitor:
+            parsed.monitor !== undefined
+              ? parsed.monitor
+              : (extractSelected(current["monitor"]) ?? current["monitor"] ?? ""),
+          force_down: extractSelected(current["force_down"]) ?? current["force_down"] ?? "",
+          priority:
+            parsed.priority !== undefined
+              ? String(parsed.priority)
+              : (extractSelected(current["priority"]) ?? current["priority"] ?? "255"),
+          weight:
+            parsed.weight !== undefined
+              ? String(parsed.weight)
+              : (extractSelected(current["weight"]) ?? current["weight"] ?? "1"),
+          latencylow: extractSelected(current["latencylow"]) ?? current["latencylow"] ?? "",
+          latencyhigh: extractSelected(current["latencyhigh"]) ?? current["latencyhigh"] ?? "",
+          losslow: extractSelected(current["losslow"]) ?? current["losslow"] ?? "",
+          losshigh: extractSelected(current["losshigh"]) ?? current["losshigh"] ?? "",
+          interval: extractSelected(current["interval"]) ?? current["interval"] ?? "",
+          time_period: extractSelected(current["time_period"]) ?? current["time_period"] ?? "",
+          loss_interval: extractSelected(current["loss_interval"]) ?? current["loss_interval"] ?? "",
+          data_length: extractSelected(current["data_length"]) ?? current["data_length"] ?? "",
+          disabled:
+            boolToFlag(parsed.disabled) ??
+            (extractSelected(current["disabled"]) ?? current["disabled"] ?? "0"),
+        };
+
+        const result = await client.post(
+          `/routing/settings/setGateway/${encodeURIComponent(parsed.uuid)}`,
+          { gateway_item: flat },
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_route_gateway_apply": {
+        GatewayApplySchema.parse(args);
+        const result = await client.post("/routing/settings/reconfigure", {});
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 

--- a/tests/tools/routing-gateway-status.test.ts
+++ b/tests/tools/routing-gateway-status.test.ts
@@ -42,6 +42,96 @@ describe('Routing gateway status tool', () => {
     expect(result.content[0].text).toContain('monitor_disable');
   });
 
+  it('exposes opnsense_route_gateway_update + _apply definitions', () => {
+    const update = routingToolDefinitions.find((t) => t.name === 'opnsense_route_gateway_update');
+    const apply = routingToolDefinitions.find((t) => t.name === 'opnsense_route_gateway_apply');
+    expect(update).toBeDefined();
+    expect(apply).toBeDefined();
+  });
+
+  it('updates a gateway by round-tripping current config', async () => {
+    const get = vi.fn().mockResolvedValue({
+      gateway_item: {
+        name: 'WAN_GW',
+        descr: 'WAN Gateway',
+        interface: { wan: { value: 'WAN', selected: 1 }, lan: { value: 'LAN', selected: 0 } },
+        ipprotocol: { inet: { value: 'IPv4', selected: 1 }, inet6: { value: 'IPv6', selected: 0 } },
+        gateway: '',
+        defaultgw: '1',
+        monitor_disable: '1',
+        monitor: '',
+        priority: '255',
+        weight: '1',
+        disabled: '0',
+      },
+    });
+    const post = vi.fn().mockResolvedValue({ status: 'ok' });
+    const client = mockClient({ get, post } as Partial<OPNsenseClient>);
+
+    await handleRoutingTool(
+      'opnsense_route_gateway_update',
+      {
+        uuid: '983182ee-153b-47fa-bdbd-31d9fdf21602',
+        monitor_disable: false,
+        monitor: '1.1.1.1',
+        confirm: true,
+      },
+      client,
+    );
+
+    expect(get).toHaveBeenCalledWith(
+      '/routing/settings/getGateway/983182ee-153b-47fa-bdbd-31d9fdf21602',
+    );
+    const setCall = post.mock.calls.find((c) => String(c[0]).includes('setGateway')) as [string, { gateway_item: Record<string, string> }];
+    expect(setCall).toBeDefined();
+    expect(setCall[1].gateway_item.monitor_disable).toBe('0');
+    expect(setCall[1].gateway_item.monitor).toBe('1.1.1.1');
+    expect(setCall[1].gateway_item.interface).toBe('wan');
+    expect(setCall[1].gateway_item.ipprotocol).toBe('inet');
+    expect(setCall[1].gateway_item.priority).toBe('255'); // preserved
+    expect(setCall[1].gateway_item.defaultgw).toBe('1'); // preserved
+  });
+
+  it('rejects gateway_update without confirm', async () => {
+    const client = mockClient();
+    const result = await handleRoutingTool(
+      'opnsense_route_gateway_update',
+      { uuid: '983182ee-153b-47fa-bdbd-31d9fdf21602', monitor_disable: false },
+      client,
+    );
+    expect(result.content[0].text).toContain('Error');
+  });
+
+  it('coerces string "true" on gateway_update confirm (MCP transport)', async () => {
+    const get = vi.fn().mockResolvedValue({ gateway_item: { name: 'X', interface: 'wan', ipprotocol: 'inet' } });
+    const post = vi.fn().mockResolvedValue({ status: 'ok' });
+    const client = mockClient({ get, post } as Partial<OPNsenseClient>);
+    const result = await handleRoutingTool(
+      'opnsense_route_gateway_update',
+      {
+        uuid: '983182ee-153b-47fa-bdbd-31d9fdf21602',
+        monitor_disable: 'false' as unknown as boolean,
+        confirm: 'true' as unknown as true,
+      },
+      client,
+    );
+    expect(result.content[0].text).toContain('ok');
+  });
+
+  it('applies gateway changes with confirm', async () => {
+    const post = vi.fn().mockResolvedValue({ status: 'ok' });
+    const client = mockClient({ post } as Partial<OPNsenseClient>);
+    const result = await handleRoutingTool('opnsense_route_gateway_apply', { confirm: true }, client);
+    expect(result.content[0].text).toContain('ok');
+    expect(post).toHaveBeenCalledWith('/routing/settings/reconfigure', {});
+  });
+
+  it('rejects gateway_apply without confirm', async () => {
+    const client = mockClient();
+    const result = await handleRoutingTool('opnsense_route_gateway_apply', {}, client);
+    expect(result.content[0].text).toContain('Error');
+  });
+
   it('handles API errors gracefully', async () => {
     const client = mockClient({
       get: vi.fn().mockRejectedValue(new Error('Connection refused')),


### PR DESCRIPTION
Closes #115. Round-trip update tool for gateway config (toggle monitor_disable, set monitor IP, weight/priority) + apply endpoint. Verified against 25.1 API. 162/162 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)