### PR TITLE
feat: SNAT (#123 partial) + Unbound DNSBL multi-source (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.05.03.1
+
+- **feat: Source NAT (SNAT) tools** (#123 partial)
+  - 7 new tools (`opnsense_nat_source_{list,get,add,update,delete,toggle}` + `opnsense_nat_apply`) wrapping `/api/firewall/source_nat/*`
+  - Round-trip update pattern using `extractSelected()` for multi-select fields
+  - Full Zod schemas with `confirm` gate (boolean coerce per #120) on all destructive ops
+  - Verified live against OPNsense 26.1.7 "Witty Woodpecker"
+  - **DNAT (port forwarding) deferred**: probed all candidate endpoints (`firewall/destination_nat/*`, `firewall/portforward/*`, `firewall/redirect/*`, `firewall/dnat/*`) — all return 404 in 26.1.7. Will follow once OPNsense exposes a stable DNAT API.
+- **feat: Unbound DNSBL multi-source blocklist tools** (#125)
+  - 3 new tools: `opnsense_dns_blocklist_get` (read), `opnsense_dns_blocklist_sources_list` (read, with selected state), `opnsense_dns_blocklist_set` (write, requires `confirm: true`)
+  - Wraps `/api/unbound/settings/{getDnsbl,setDnsbl}` — multi-source feature moved to CE in OPNsense 26.1
+  - Discovered ~40 built-in feeds (AdGuard, EasyList, hagezi family, Steven Black, Abuse.ch, etc.)
+  - Round-trip pattern preserves currently-selected sources when caller omits `sources`
+- 19 new unit tests (181 total green)
+
 ## v2026.05.02.1
 
 - **feat: add opnsense_route_gateway_update + _apply** (#115)

--- a/README.md
+++ b/README.md
@@ -305,7 +305,9 @@ populated-count appear in stderr diagnostics. The loader uses the global
 
 ## Available Tools (87)
 
-### DNS/Unbound (12 tools)
+### DNS/Unbound (19 tools)
+
+Includes DNSBL (multi-source blocklist) management — `opnsense_dns_blocklist_get`, `opnsense_dns_blocklist_sources_list`, `opnsense_dns_blocklist_set` — for OPNsense 26.1+.
 
 | Tool | Description |
 |------|-------------|
@@ -321,6 +323,22 @@ populated-count appear in stderr diagnostics. The loader uses the global
 | `opnsense_dns_flush_cache` | Flush DNS cache and DNSBL data |
 | `opnsense_dns_diagnostics` | Dump DNS cache for diagnostics |
 | `opnsense_dns_apply` | Apply DNS changes (reconfigure Unbound) |
+
+### NAT (7 tools)
+
+Source NAT (outbound) tools wrapping `/api/firewall/source_nat/*` (OPNsense 26.1+):
+
+| Tool | Description |
+|------|-------------|
+| `opnsense_nat_source_list` | List all SNAT rules |
+| `opnsense_nat_source_get` | Get a single SNAT rule by UUID |
+| `opnsense_nat_source_add` | Add a SNAT rule (requires `confirm: true`) |
+| `opnsense_nat_source_update` | Round-trip update of an existing SNAT rule (requires `confirm: true`) |
+| `opnsense_nat_source_delete` | Delete a SNAT rule (requires `confirm: true`) |
+| `opnsense_nat_source_toggle` | Toggle a SNAT rule's enabled state (requires `confirm: true`) |
+| `opnsense_nat_apply` | Apply pending NAT changes (requires `confirm: true`) |
+
+Note: Destination NAT (port forwarding) endpoints are not yet exposed by OPNsense 26.1.7; see issue #123 for the deferred portion.
 
 ### Firewall (10 tools)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified.io/mcp-opnsense",
-  "version": "2026.5.2-1",
+  "version": "2026.5.3-1",
   "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { firmwareToolDefinitions, handleFirmwareTool } from './tools/firmware.js
 import { routingToolDefinitions, handleRoutingTool } from './tools/routing.js';
 import { vlanToolDefinitions, handleVlanTool } from './tools/vlan.js';
 import { tailscaleToolDefinitions, handleTailscaleTool } from './tools/tailscale.js';
+import { natToolDefinitions, handleNatTool } from './tools/nat.js';
 
 const allToolDefinitions = [
   ...dnsToolDefinitions,
@@ -47,6 +48,7 @@ const allToolDefinitions = [
   ...routingToolDefinitions,
   ...vlanToolDefinitions,
   ...tailscaleToolDefinitions,
+  ...natToolDefinitions,
 ];
 
 const toolHandlers = new Map<
@@ -65,6 +67,7 @@ for (const def of firmwareToolDefinitions) toolHandlers.set(def.name, handleFirm
 for (const def of routingToolDefinitions) toolHandlers.set(def.name, handleRoutingTool);
 for (const def of vlanToolDefinitions) toolHandlers.set(def.name, handleVlanTool);
 for (const def of tailscaleToolDefinitions) toolHandlers.set(def.name, handleTailscaleTool);
+for (const def of natToolDefinitions) toolHandlers.set(def.name, handleNatTool);
 
 const server = new Server(
   { name: 'mcp-opnsense', version: '2026.4.10-4' },

--- a/src/tools/dns.ts
+++ b/src/tools/dns.ts
@@ -46,6 +46,27 @@ const DnsFlushZoneSchema = z.object({
   domain: DomainSchema,
 });
 
+// DNSBL multi-source (26.1+, OPNsense moved this to CE)
+const ConfirmTrueDnsbl = z.preprocess(
+  (v) => (v === "true" ? true : v === "false" ? false : v),
+  z.literal(true, {
+    errorMap: () => ({ message: "confirm must be true to update DNSBL configuration" }),
+  }),
+);
+const CoerceBoolDnsbl = z.preprocess((v) => {
+  if (v === "true" || v === "1" || v === 1) return true;
+  if (v === "false" || v === "0" || v === 0) return false;
+  return v;
+}, z.boolean());
+
+const BlocklistSetSchema = z.object({
+  enabled: CoerceBoolDnsbl.optional(),
+  sources: z.array(z.string()).optional(),
+  custom_lists: z.string().optional(),
+  nxdomain: CoerceBoolDnsbl.optional(),
+  confirm: ConfirmTrueDnsbl,
+});
+
 const DnsCacheSearchSchema = z.object({
   domain: z.string().min(1, "Domain filter is required"),
 });
@@ -211,6 +232,51 @@ export const dnsToolDefinitions = [
       "Dump the Unbound infrastructure cache showing upstream server RTT, EDNS support, and lame delegation status. Useful for diagnosing upstream DNS connectivity issues.",
     inputSchema: { type: "object" as const, properties: {} },
   },
+  {
+    name: "opnsense_dns_blocklist_get",
+    description:
+      "Get the Unbound DNSBL (DNS blocklist) configuration: enabled flag, selected built-in source IDs, custom URLs, NX-domain mode, allowlist. Read-only.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_dns_blocklist_sources_list",
+    description:
+      "List all available built-in DNSBL block-list sources (curated feeds like AdGuard, EasyList, hagezi, Steven Black, etc.) with their internal IDs and selected state. Read-only.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_dns_blocklist_set",
+    description:
+      "Update the Unbound DNSBL configuration: enable/disable, select multiple built-in source IDs, set custom blocklist URLs, configure NX-domain mode. After this, call opnsense_dns_apply to activate. DESTRUCTIVE: requires explicit confirmation.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        enabled: {
+          type: "boolean",
+          description: "Master enable for the DNSBL feature",
+        },
+        sources: {
+          type: "array",
+          items: { type: "string" },
+          description: "List of built-in source IDs to enable (use opnsense_dns_blocklist_sources_list to discover available IDs, e.g. 'hgz002', 'sb', 'ag')",
+        },
+        custom_lists: {
+          type: "string",
+          description: "Comma- or newline-separated list of custom blocklist URLs (one per line)",
+        },
+        nxdomain: {
+          type: "boolean",
+          description: "Return NXDOMAIN instead of 0.0.0.0 for blocked entries",
+        },
+        confirm: {
+          type: "boolean",
+          enum: [true],
+          description: "Must be true to apply the change",
+        },
+      },
+      required: ["confirm"],
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -366,6 +432,72 @@ export async function handleDnsTool(
 
       case "opnsense_dns_infra": {
         const result = await client.get("/unbound/diagnostics/dumpinfra");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_blocklist_get": {
+        const result = await client.get("/unbound/settings/getDnsbl");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_dns_blocklist_sources_list": {
+        const raw = (await client.get<{ blocklist?: { type?: Record<string, unknown> } }>(
+          "/unbound/settings/getDnsbl",
+        ));
+        const types = raw?.blocklist?.type ?? {};
+        const sources: Array<{ id: string; name: string; selected: boolean }> = [];
+        for (const [id, v] of Object.entries(types)) {
+          if (v && typeof v === "object") {
+            const o = v as Record<string, unknown>;
+            sources.push({
+              id,
+              name: String(o.value ?? ""),
+              selected: o.selected === 1 || o.selected === "1",
+            });
+          }
+        }
+        return { content: [{ type: "text", text: JSON.stringify({ sources, total: sources.length }, null, 2) }] };
+      }
+
+      case "opnsense_dns_blocklist_set": {
+        const p = BlocklistSetSchema.parse(args);
+        const current = (await client.get<{ blocklist?: Record<string, unknown> }>(
+          "/unbound/settings/getDnsbl",
+        ))?.blocklist ?? {};
+
+        // Read currently-selected source IDs (multi-select)
+        const currentTypeObj = (current["type"] as Record<string, unknown>) ?? {};
+        const currentSources: string[] = [];
+        for (const [id, v] of Object.entries(currentTypeObj)) {
+          if (v && typeof v === "object" && ((v as Record<string, unknown>).selected === 1 || (v as Record<string, unknown>).selected === "1")) {
+            currentSources.push(id);
+          }
+        }
+
+        const payload: Record<string, unknown> = {
+          enabled:
+            p.enabled === undefined
+              ? (current["enabled"] ?? "1")
+              : (p.enabled ? "1" : "0"),
+          // OPNsense expects multi-select as comma-separated IDs
+          type: (p.sources ?? currentSources).join(","),
+          lists:
+            p.custom_lists !== undefined
+              ? p.custom_lists
+              : (current["lists"] ?? ""),
+          nxdomain:
+            p.nxdomain === undefined
+              ? (current["nxdomain"] ?? "0")
+              : (p.nxdomain ? "1" : "0"),
+          // Preserve other fields if present
+          whitelists: current["whitelists"] ?? "",
+          blocklists: current["blocklists"] ?? "",
+          wildcards: current["wildcards"] ?? "",
+          address: current["address"] ?? "",
+          safesearch: current["safesearch"] ?? "0",
+        };
+
+        const result = await client.post("/unbound/settings/setDnsbl", { blocklist: payload });
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 

--- a/src/tools/nat.ts
+++ b/src/tools/nat.ts
@@ -1,0 +1,344 @@
+import { z } from "zod";
+import type { OPNsenseClient } from "../client/opnsense-client.js";
+import { UuidSchema } from "../utils/validation.js";
+import { extractSelected } from "./firewall.js";
+
+// MCP transports may serialize booleans as strings — coerce "true"/"false"
+// before the literal check (see #120).
+const ConfirmTrue = (msg: string) =>
+  z.preprocess(
+    (v) => (v === "true" ? true : v === "false" ? false : v),
+    z.literal(true, { errorMap: () => ({ message: msg }) }),
+  );
+
+const CoerceBoolean = z.preprocess((v) => {
+  if (v === "true" || v === "1" || v === 1) return true;
+  if (v === "false" || v === "0" || v === 0) return false;
+  return v;
+}, z.boolean());
+
+// ---------------------------------------------------------------------------
+// Source NAT (outbound) — wraps /api/firewall/source_nat/* endpoints
+// introduced/finalized in OPNsense 26.1 "Witty Woodpecker".
+//
+// Note: Destination NAT (port forwarding) does NOT yet have a dedicated
+// modern API endpoint in OPNsense 26.1.7 (all probed paths return 404).
+// DNAT support will follow in a separate change once OPNsense exposes it.
+// ---------------------------------------------------------------------------
+
+const SourceNatAddSchema = z.object({
+  enabled: CoerceBoolean.optional().default(true),
+  interface: z.string().min(1, "interface is required (e.g. 'wan')"),
+  ipprotocol: z.enum(["inet", "inet6"]).optional().default("inet"),
+  protocol: z.string().optional(), // any | TCP | UDP | TCP/UDP | ...
+  source_net: z.string().optional().default("any"),
+  source_not: CoerceBoolean.optional().default(false),
+  source_port: z.string().optional(),
+  destination_net: z.string().optional().default("any"),
+  destination_not: CoerceBoolean.optional().default(false),
+  destination_port: z.string().optional(),
+  target: z.string().optional().default("wanip"), // wanip | <ip> | host alias
+  target_port: z.string().optional(),
+  staticnatport: CoerceBoolean.optional().default(false),
+  nonat: CoerceBoolean.optional().default(false),
+  log: CoerceBoolean.optional().default(false),
+  sequence: z.coerce.number().int().min(1).max(99999).optional().default(100),
+  tagged: z.string().optional(),
+  description: z.string().optional(),
+  confirm: ConfirmTrue("confirm must be true to add a source NAT rule"),
+});
+
+const SourceNatUpdateSchema = z.object({
+  uuid: UuidSchema,
+  enabled: CoerceBoolean.optional(),
+  interface: z.string().optional(),
+  ipprotocol: z.enum(["inet", "inet6"]).optional(),
+  protocol: z.string().optional(),
+  source_net: z.string().optional(),
+  source_not: CoerceBoolean.optional(),
+  source_port: z.string().optional(),
+  destination_net: z.string().optional(),
+  destination_not: CoerceBoolean.optional(),
+  destination_port: z.string().optional(),
+  target: z.string().optional(),
+  target_port: z.string().optional(),
+  staticnatport: CoerceBoolean.optional(),
+  nonat: CoerceBoolean.optional(),
+  log: CoerceBoolean.optional(),
+  sequence: z.coerce.number().int().min(1).max(99999).optional(),
+  tagged: z.string().optional(),
+  description: z.string().optional(),
+  confirm: ConfirmTrue("confirm must be true to update a source NAT rule"),
+});
+
+const SourceNatUuidConfirmSchema = z.object({
+  uuid: UuidSchema,
+  confirm: ConfirmTrue("confirm must be true to proceed"),
+});
+
+const ApplySchema = z.object({
+  confirm: ConfirmTrue("confirm must be true to apply NAT configuration"),
+});
+
+function flag(b: boolean | undefined): string | undefined {
+  if (b === undefined) return undefined;
+  return b ? "1" : "0";
+}
+
+// ---------------------------------------------------------------------------
+
+export const natToolDefinitions = [
+  {
+    name: "opnsense_nat_source_list",
+    description:
+      "List all Source NAT (outbound) rules. Read-only. Returns rule UUID, sequence, interface, source/destination, target, enabled state.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_nat_source_get",
+    description: "Get a single Source NAT rule by UUID with full configuration. Read-only.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "Source NAT rule UUID" },
+      },
+      required: ["uuid"],
+    },
+  },
+  {
+    name: "opnsense_nat_source_add",
+    description:
+      "Add a new Source NAT (outbound) rule. After adding, call opnsense_nat_apply to activate. DESTRUCTIVE: requires explicit confirmation.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        enabled: { type: "boolean", description: "Rule enabled (default: true)" },
+        interface: { type: "string", description: "Interface name (e.g. 'wan', 'lan', 'opt1')" },
+        ipprotocol: { type: "string", enum: ["inet", "inet6"], description: "IP version" },
+        protocol: { type: "string", description: "Protocol: any/TCP/UDP/TCP/UDP/ICMP/..." },
+        source_net: { type: "string", description: "Source network (any/CIDR/alias). Default: any" },
+        source_not: { type: "boolean", description: "Invert source match" },
+        source_port: { type: "string", description: "Source port/range" },
+        destination_net: { type: "string", description: "Destination network. Default: any" },
+        destination_not: { type: "boolean", description: "Invert destination match" },
+        destination_port: { type: "string", description: "Destination port/range" },
+        target: { type: "string", description: "Translation target: 'wanip' (default), specific IP, or alias" },
+        target_port: { type: "string", description: "Translation target port" },
+        staticnatport: { type: "boolean", description: "Use static source port" },
+        nonat: { type: "boolean", description: "If true, exclude this traffic from NAT (no-NAT rule)" },
+        log: { type: "boolean", description: "Log packets matching this rule" },
+        sequence: { type: "number", description: "Rule order (default: 100)" },
+        tagged: { type: "string", description: "Match a packet tag set by another rule" },
+        description: { type: "string", description: "Human-readable description" },
+        confirm: { type: "boolean", description: "Must be true to confirm", enum: [true] },
+      },
+      required: ["interface", "confirm"],
+    },
+  },
+  {
+    name: "opnsense_nat_source_update",
+    description:
+      "Update an existing Source NAT rule. Round-trips current config and only overrides explicitly provided fields. DESTRUCTIVE.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "Rule UUID" },
+        enabled: { type: "boolean" },
+        interface: { type: "string" },
+        ipprotocol: { type: "string", enum: ["inet", "inet6"] },
+        protocol: { type: "string" },
+        source_net: { type: "string" },
+        source_not: { type: "boolean" },
+        source_port: { type: "string" },
+        destination_net: { type: "string" },
+        destination_not: { type: "boolean" },
+        destination_port: { type: "string" },
+        target: { type: "string" },
+        target_port: { type: "string" },
+        staticnatport: { type: "boolean" },
+        nonat: { type: "boolean" },
+        log: { type: "boolean" },
+        sequence: { type: "number" },
+        tagged: { type: "string" },
+        description: { type: "string" },
+        confirm: { type: "boolean", enum: [true] },
+      },
+      required: ["uuid", "confirm"],
+    },
+  },
+  {
+    name: "opnsense_nat_source_delete",
+    description: "Delete a Source NAT rule. DESTRUCTIVE: requires explicit confirmation.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string", description: "Rule UUID" },
+        confirm: { type: "boolean", enum: [true] },
+      },
+      required: ["uuid", "confirm"],
+    },
+  },
+  {
+    name: "opnsense_nat_source_toggle",
+    description: "Toggle a Source NAT rule's enabled state. DESTRUCTIVE: requires explicit confirmation.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        uuid: { type: "string" },
+        confirm: { type: "boolean", enum: [true] },
+      },
+      required: ["uuid", "confirm"],
+    },
+  },
+  {
+    name: "opnsense_nat_apply",
+    description:
+      "Apply pending NAT configuration changes. Required after add/update/delete/toggle for changes to take effect. DESTRUCTIVE.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        confirm: { type: "boolean", enum: [true] },
+      },
+      required: ["confirm"],
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+
+export async function handleNatTool(
+  name: string,
+  args: Record<string, unknown>,
+  client: OPNsenseClient,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    switch (name) {
+      case "opnsense_nat_source_list": {
+        const result = await client.get("/firewall/source_nat/search_rule");
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_nat_source_get": {
+        const uuid = z.object({ uuid: UuidSchema }).parse(args).uuid;
+        const result = await client.get(
+          `/firewall/source_nat/get_rule/${encodeURIComponent(uuid)}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_nat_source_add": {
+        const p = SourceNatAddSchema.parse(args);
+        const rule: Record<string, unknown> = {
+          enabled: flag(p.enabled),
+          interface: p.interface,
+          ipprotocol: p.ipprotocol,
+          protocol: p.protocol ?? "",
+          source_net: p.source_net,
+          source_not: flag(p.source_not),
+          source_port: p.source_port ?? "",
+          destination_net: p.destination_net,
+          destination_not: flag(p.destination_not),
+          destination_port: p.destination_port ?? "",
+          target: p.target ?? "",
+          target_port: p.target_port ?? "",
+          staticnatport: flag(p.staticnatport),
+          nonat: flag(p.nonat),
+          log: flag(p.log),
+          sequence: String(p.sequence),
+          tagged: p.tagged ?? "",
+          description: p.description ?? "",
+        };
+        const result = await client.post("/firewall/source_nat/add_rule", { rule });
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_nat_source_update": {
+        const p = SourceNatUpdateSchema.parse(args);
+        const current = (await client.get<{ rule?: Record<string, unknown> }>(
+          `/firewall/source_nat/get_rule/${encodeURIComponent(p.uuid)}`,
+        ))?.rule ?? {};
+
+        const merged: Record<string, unknown> = {
+          enabled:
+            flag(p.enabled) ??
+            (extractSelected(current["enabled"]) ?? current["enabled"] ?? "1"),
+          interface:
+            p.interface ?? extractSelected(current["interface"]) ?? "",
+          ipprotocol:
+            p.ipprotocol ?? extractSelected(current["ipprotocol"]) ?? "inet",
+          protocol:
+            p.protocol ?? extractSelected(current["protocol"]) ?? "",
+          source_net:
+            p.source_net ?? (extractSelected(current["source_net"]) ?? current["source_net"] ?? "any"),
+          source_not:
+            flag(p.source_not) ??
+            (extractSelected(current["source_not"]) ?? current["source_not"] ?? "0"),
+          source_port:
+            p.source_port ?? (extractSelected(current["source_port"]) ?? current["source_port"] ?? ""),
+          destination_net:
+            p.destination_net ?? (extractSelected(current["destination_net"]) ?? current["destination_net"] ?? "any"),
+          destination_not:
+            flag(p.destination_not) ??
+            (extractSelected(current["destination_not"]) ?? current["destination_not"] ?? "0"),
+          destination_port:
+            p.destination_port ?? (extractSelected(current["destination_port"]) ?? current["destination_port"] ?? ""),
+          target:
+            p.target ?? (extractSelected(current["target"]) ?? current["target"] ?? ""),
+          target_port:
+            p.target_port ?? (extractSelected(current["target_port"]) ?? current["target_port"] ?? ""),
+          staticnatport:
+            flag(p.staticnatport) ??
+            (extractSelected(current["staticnatport"]) ?? current["staticnatport"] ?? "0"),
+          nonat:
+            flag(p.nonat) ??
+            (extractSelected(current["nonat"]) ?? current["nonat"] ?? "0"),
+          log:
+            flag(p.log) ??
+            (extractSelected(current["log"]) ?? current["log"] ?? "0"),
+          sequence:
+            p.sequence !== undefined
+              ? String(p.sequence)
+              : (extractSelected(current["sequence"]) ?? current["sequence"] ?? "100"),
+          tagged:
+            p.tagged ?? (extractSelected(current["tagged"]) ?? current["tagged"] ?? ""),
+          description:
+            p.description ?? (extractSelected(current["description"]) ?? current["description"] ?? ""),
+        };
+
+        const result = await client.post(
+          `/firewall/source_nat/set_rule/${encodeURIComponent(p.uuid)}`,
+          { rule: merged },
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_nat_source_delete": {
+        const p = SourceNatUuidConfirmSchema.parse(args);
+        const result = await client.post(
+          `/firewall/source_nat/del_rule/${encodeURIComponent(p.uuid)}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_nat_source_toggle": {
+        const p = SourceNatUuidConfirmSchema.parse(args);
+        const result = await client.post(
+          `/firewall/source_nat/toggle_rule/${encodeURIComponent(p.uuid)}`,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_nat_apply": {
+        ApplySchema.parse(args);
+        const result = await client.post("/firewall/source_nat/apply", {});
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        return { content: [{ type: "text", text: `Unknown NAT tool: ${name}` }] };
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return { content: [{ type: "text", text: `Error executing ${name}: ${message}` }] };
+  }
+}

--- a/tests/tools/dns-blocklist.test.ts
+++ b/tests/tools/dns-blocklist.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { dnsToolDefinitions, handleDnsTool } from '../../src/tools/dns.js';
+import type { OPNsenseClient } from '../../src/client/opnsense-client.js';
+
+function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
+  return {
+    get: vi.fn().mockResolvedValue({}),
+    post: vi.fn().mockResolvedValue({ result: 'saved' }),
+    delete: vi.fn().mockResolvedValue({ status: 'ok' }),
+    ...overrides,
+  } as unknown as OPNsenseClient;
+}
+
+const SAMPLE_DNSBL = {
+  blocklist: {
+    enabled: '1',
+    type: {
+      atf: { value: 'Abuse.ch ThreatFox', selected: 0 },
+      ag: { value: 'AdGuard', selected: 1 },
+      hgz002: { value: 'hagezi NORMAL', selected: 1 },
+      sb: { value: 'Steven Black', selected: 0 },
+    },
+    lists: '',
+    nxdomain: '0',
+  },
+};
+
+describe('Unbound DNSBL tool definitions', () => {
+  it('exposes the 3 new blocklist tools', () => {
+    const names = dnsToolDefinitions.map((t) => t.name);
+    expect(names).toContain('opnsense_dns_blocklist_get');
+    expect(names).toContain('opnsense_dns_blocklist_sources_list');
+    expect(names).toContain('opnsense_dns_blocklist_set');
+  });
+});
+
+describe('handleDnsTool — DNSBL', () => {
+  it('gets the raw blocklist config', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue(SAMPLE_DNSBL) });
+    const r = await handleDnsTool('opnsense_dns_blocklist_get', {}, client);
+    expect(client.get).toHaveBeenCalledWith('/unbound/settings/getDnsbl');
+    expect(r.content[0].text).toContain('hgz002');
+  });
+
+  it('lists available sources with selected state', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue(SAMPLE_DNSBL) });
+    const r = await handleDnsTool('opnsense_dns_blocklist_sources_list', {}, client);
+    const out = JSON.parse(r.content[0].text);
+    expect(out.total).toBe(4);
+    const ag = out.sources.find((s: { id: string }) => s.id === 'ag');
+    expect(ag).toEqual({ id: 'ag', name: 'AdGuard', selected: true });
+    const atf = out.sources.find((s: { id: string }) => s.id === 'atf');
+    expect(atf.selected).toBe(false);
+  });
+
+  it('sets blocklist enabling new sources, preserving existing fields', async () => {
+    const get = vi.fn().mockResolvedValue(SAMPLE_DNSBL);
+    const post = vi.fn().mockResolvedValue({ result: 'saved' });
+    const client = mockClient({ get, post } as Partial<OPNsenseClient>);
+
+    await handleDnsTool(
+      'opnsense_dns_blocklist_set',
+      { sources: ['ag', 'hgz002', 'sb'], enabled: true, confirm: true },
+      client,
+    );
+
+    expect(post).toHaveBeenCalledWith('/unbound/settings/setDnsbl', expect.any(Object));
+    const [, body] = post.mock.calls[0] as [string, { blocklist: Record<string, unknown> }];
+    expect(body.blocklist.enabled).toBe('1');
+    expect(body.blocklist.type).toBe('ag,hgz002,sb');
+    expect(body.blocklist.nxdomain).toBe('0'); // preserved
+  });
+
+  it('rejects set without confirm', async () => {
+    const client = mockClient();
+    const r = await handleDnsTool(
+      'opnsense_dns_blocklist_set',
+      { sources: ['ag'] },
+      client,
+    );
+    expect(r.content[0].text).toContain('Error');
+  });
+
+  it('coerces string "true" on confirm (MCP transport)', async () => {
+    const get = vi.fn().mockResolvedValue(SAMPLE_DNSBL);
+    const post = vi.fn().mockResolvedValue({ result: 'saved' });
+    const client = mockClient({ get, post } as Partial<OPNsenseClient>);
+    const r = await handleDnsTool(
+      'opnsense_dns_blocklist_set',
+      { confirm: 'true' as unknown as true },
+      client,
+    );
+    expect(r.content[0].text).toContain('saved');
+  });
+
+  it('preserves currently-selected sources when sources arg omitted', async () => {
+    const get = vi.fn().mockResolvedValue(SAMPLE_DNSBL);
+    const post = vi.fn().mockResolvedValue({ result: 'saved' });
+    const client = mockClient({ get, post } as Partial<OPNsenseClient>);
+    await handleDnsTool(
+      'opnsense_dns_blocklist_set',
+      { nxdomain: true, confirm: true },
+      client,
+    );
+    const [, body] = post.mock.calls[0] as [string, { blocklist: Record<string, string> }];
+    // Only ag + hgz002 were selected in SAMPLE_DNSBL
+    expect(body.blocklist.type).toBe('ag,hgz002');
+    expect(body.blocklist.nxdomain).toBe('1');
+  });
+});

--- a/tests/tools/dns.test.ts
+++ b/tests/tools/dns.test.ts
@@ -12,8 +12,8 @@ function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
 }
 
 describe('DNS Tool Definitions', () => {
-  it('exports 16 tool definitions', () => {
-    expect(dnsToolDefinitions).toHaveLength(16);
+  it('exports 19 tool definitions', () => {
+    expect(dnsToolDefinitions).toHaveLength(19);
   });
 
   it('all tools have opnsense_dns_ prefix', () => {

--- a/tests/tools/nat.test.ts
+++ b/tests/tools/nat.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest';
+import { natToolDefinitions, handleNatTool } from '../../src/tools/nat.js';
+import type { OPNsenseClient } from '../../src/client/opnsense-client.js';
+
+function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
+  return {
+    get: vi.fn().mockResolvedValue({}),
+    post: vi.fn().mockResolvedValue({ result: 'saved' }),
+    delete: vi.fn().mockResolvedValue({ status: 'ok' }),
+    ...overrides,
+  } as unknown as OPNsenseClient;
+}
+
+describe('NAT tool definitions', () => {
+  it('exports 7 SNAT tools', () => {
+    expect(natToolDefinitions).toHaveLength(7);
+  });
+  it('all start with opnsense_nat_', () => {
+    for (const t of natToolDefinitions) expect(t.name).toMatch(/^opnsense_nat_/);
+  });
+});
+
+describe('handleNatTool', () => {
+  it('lists source NAT rules', async () => {
+    const client = mockClient({
+      get: vi.fn().mockResolvedValue({ rows: [], total: 0 }),
+    });
+    const r = await handleNatTool('opnsense_nat_source_list', {}, client);
+    expect(client.get).toHaveBeenCalledWith('/firewall/source_nat/search_rule');
+    expect(r.content[0].text).toContain('total');
+  });
+
+  it('gets a single source NAT rule', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue({ rule: { enabled: '1' } }) });
+    await handleNatTool(
+      'opnsense_nat_source_get',
+      { uuid: '0695b31d-3fe9-47ea-8473-81779edddf34' },
+      client,
+    );
+    expect(client.get).toHaveBeenCalledWith(
+      '/firewall/source_nat/get_rule/0695b31d-3fe9-47ea-8473-81779edddf34',
+    );
+  });
+
+  it('adds a SNAT rule with confirm', async () => {
+    const post = vi.fn().mockResolvedValue({ result: 'saved', uuid: 'new-uuid' });
+    const client = mockClient({ post } as Partial<OPNsenseClient>);
+    await handleNatTool(
+      'opnsense_nat_source_add',
+      {
+        interface: 'wan',
+        target: 'wanip',
+        source_net: '10.10.0.0/24',
+        confirm: true,
+      },
+      client,
+    );
+    expect(post).toHaveBeenCalledWith('/firewall/source_nat/add_rule', expect.any(Object));
+    const [, body] = post.mock.calls[0] as [string, { rule: Record<string, unknown> }];
+    expect(body.rule.interface).toBe('wan');
+    expect(body.rule.target).toBe('wanip');
+    expect(body.rule.source_net).toBe('10.10.0.0/24');
+    expect(body.rule.enabled).toBe('1');
+  });
+
+  it('rejects add without confirm', async () => {
+    const client = mockClient();
+    const r = await handleNatTool(
+      'opnsense_nat_source_add',
+      { interface: 'wan' },
+      client,
+    );
+    expect(r.content[0].text).toContain('Error');
+  });
+
+  it('coerces string "true" on confirm (MCP transport)', async () => {
+    const post = vi.fn().mockResolvedValue({ result: 'saved' });
+    const client = mockClient({ post } as Partial<OPNsenseClient>);
+    const r = await handleNatTool(
+      'opnsense_nat_source_add',
+      { interface: 'wan', confirm: 'true' as unknown as true },
+      client,
+    );
+    expect(r.content[0].text).toContain('saved');
+  });
+
+  it('updates a SNAT rule by round-tripping current config', async () => {
+    const get = vi.fn().mockResolvedValue({
+      rule: {
+        enabled: '1',
+        interface: { wan: { value: 'WAN', selected: 1 }, lan: { value: 'LAN', selected: 0 } },
+        ipprotocol: { inet: { value: 'IPv4', selected: 1 }, inet6: { value: 'IPv6', selected: 0 } },
+        source_net: 'any',
+        destination_net: '10.0.0.0/8',
+        target: 'wanip',
+        sequence: '100',
+      },
+    });
+    const post = vi.fn().mockResolvedValue({ result: 'saved' });
+    const client = mockClient({ get, post } as Partial<OPNsenseClient>);
+
+    await handleNatTool(
+      'opnsense_nat_source_update',
+      {
+        uuid: '0695b31d-3fe9-47ea-8473-81779edddf34',
+        description: 'updated by mcp',
+        confirm: true,
+      },
+      client,
+    );
+
+    const [, body] = post.mock.calls[0] as [string, { rule: Record<string, string> }];
+    expect(body.rule.description).toBe('updated by mcp');
+    // preserved values
+    expect(body.rule.interface).toBe('wan');
+    expect(body.rule.ipprotocol).toBe('inet');
+    expect(body.rule.destination_net).toBe('10.0.0.0/8');
+    expect(body.rule.target).toBe('wanip');
+  });
+
+  it('deletes a SNAT rule', async () => {
+    const post = vi.fn().mockResolvedValue({ result: 'deleted' });
+    const client = mockClient({ post } as Partial<OPNsenseClient>);
+    await handleNatTool(
+      'opnsense_nat_source_delete',
+      { uuid: '0695b31d-3fe9-47ea-8473-81779edddf34', confirm: true },
+      client,
+    );
+    expect(post).toHaveBeenCalledWith(
+      '/firewall/source_nat/del_rule/0695b31d-3fe9-47ea-8473-81779edddf34',
+    );
+  });
+
+  it('toggles a SNAT rule', async () => {
+    const post = vi.fn().mockResolvedValue({ result: 'toggled' });
+    const client = mockClient({ post } as Partial<OPNsenseClient>);
+    await handleNatTool(
+      'opnsense_nat_source_toggle',
+      { uuid: '0695b31d-3fe9-47ea-8473-81779edddf34', confirm: true },
+      client,
+    );
+    expect(post).toHaveBeenCalledWith(
+      '/firewall/source_nat/toggle_rule/0695b31d-3fe9-47ea-8473-81779edddf34',
+    );
+  });
+
+  it('applies pending NAT changes', async () => {
+    const post = vi.fn().mockResolvedValue({ status: 'ok' });
+    const client = mockClient({ post } as Partial<OPNsenseClient>);
+    await handleNatTool('opnsense_nat_apply', { confirm: true }, client);
+    expect(post).toHaveBeenCalledWith('/firewall/source_nat/apply', {});
+  });
+
+  it('rejects apply without confirm', async () => {
+    const client = mockClient();
+    const r = await handleNatTool('opnsense_nat_apply', {}, client);
+    expect(r.content[0].text).toContain('Error');
+  });
+});


### PR DESCRIPTION
Implements Wave 1+2 from the post-26.1 enhancement queue.

### #123 partial — Source NAT
7 new tools wrapping `/api/firewall/source_nat/*` (verified live on 26.1.7). DNAT (port forwarding) deferred: all candidate endpoints probed, none exposed in 26.1.7. See issue #123 for the deferred portion.

### #125 — Unbound multi-source DNSBL
3 new tools wrapping `/api/unbound/settings/{getDnsbl,setDnsbl}`. Multi-source feature moved to CE in 26.1, ~40 built-in feeds discovered.

### Test plan
- [x] `npm run build` passes
- [x] `npm test` — 181/181 (19 new)
- [x] CHANGELOG + README + package.json bumped (v2026.05.03.1)
- [x] Live API spike verified endpoints

Closes #125. Partially addresses #123 (DNAT deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)