### PR TITLE
feat: system_tunable_list / get / set tools (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.05.06.1
+
+- **feat: System tunables tools** (#133)
+  - 3 new tools: `opnsense_sys_tunable_list`, `opnsense_sys_tunable_get`, `opnsense_sys_tunable_set`
+  - Wraps OPNsense `/api/system/settings/{searchTunable,addTunable,setTunable,reconfigure}` endpoints (Path A: persists in OPNsense config across reboots)
+  - `set` is upsert by sysctl name — creates if missing, updates if existing — and auto-applies via `reconfigure` (toggle off via `apply: false` to batch multiple updates)
+  - `get` accepts the sysctl name and returns either the configured row (incl. UUID) or a `{configured: false}` sentinel indicating the tunable is using its FreeBSD default
+  - Enables MCP-first verification + remediation of hardware quirks (e.g. `dev.em.0.eee_control=0` for Intel `em` LPI bug, equivalent Realtek EEE knobs), performance tuning (`net.inet.tcp.recvspace`, `kern.ipc.somaxconn`), and arbitrary kernel parameter overrides without UI/SSH fallback
+  - 7 new vitest unit tests (full handler matrix incl. add/update/skip-apply/invalid-name)
+  - System tools count: 7 → 10
+
 ## v2026.05.03.1
 
 - **feat: Source NAT (SNAT) tools** (#123 partial)

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ spike, empirical findings, and rollback contract.
 | `opnsense_dhcp_add_static` | Add a static DHCP mapping |
 | `opnsense_dhcp_delete_static` | Delete a static mapping by UUID |
 
-### System (7 tools)
+### System (10 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -474,6 +474,9 @@ spike, empirical findings, and rollback contract.
 | `opnsense_sys_list_certs` | List all certificates in the trust store |
 | `opnsense_svc_list` | List all services and their running status |
 | `opnsense_svc_control` | Start, stop, or restart a service by name |
+| `opnsense_sys_tunable_list` | List all configured FreeBSD sysctl tunables (System → Settings → Tunables) |
+| `opnsense_sys_tunable_get` | Get a single configured tunable by sysctl name |
+| `opnsense_sys_tunable_set` | Upsert a tunable (creates or updates) and optionally apply via reconfigure |
 
 ### ACME/Let's Encrypt (14 tools)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified.io/mcp-opnsense",
-  "version": "2026.5.3-1",
+  "version": "2026.5.6-1",
   "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ for (const def of tailscaleToolDefinitions) toolHandlers.set(def.name, handleTai
 for (const def of natToolDefinitions) toolHandlers.set(def.name, handleNatTool);
 
 const server = new Server(
-  { name: 'mcp-opnsense', version: '2026.4.10-4' },
+  { name: 'mcp-opnsense', version: '2026.5.6-1' },
   { capabilities: { tools: {} } }
 );
 

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -22,6 +22,41 @@ const BackupDownloadSchema = z.object({
     .describe("Specific backup ID to download. If omitted, downloads the current running config."),
 });
 
+// FreeBSD sysctl name pattern: hierarchical dot-separated identifiers
+// e.g. "dev.em.0.eee_control", "net.inet.tcp.recvspace", "kern.ipc.somaxconn"
+const TunableNameSchema = z
+  .string()
+  .min(1, "Tunable name is required")
+  .regex(
+    /^[A-Za-z0-9_.]+$/,
+    "Tunable name must be a FreeBSD sysctl identifier (alphanumeric + dot + underscore)",
+  );
+
+const TunableGetSchema = z.object({
+  tunable: TunableNameSchema.describe(
+    "FreeBSD sysctl name (e.g. 'dev.em.0.eee_control', 'net.inet.tcp.recvspace')",
+  ),
+});
+
+const TunableSetSchema = z.object({
+  tunable: TunableNameSchema.describe("FreeBSD sysctl name (e.g. 'dev.em.0.eee_control')"),
+  value: z
+    .string()
+    .min(1, "Tunable value is required")
+    .describe("Value to set (numbers and strings are both passed as strings, matching OPNsense API)"),
+  descr: z
+    .string()
+    .optional()
+    .describe("Optional description / rationale (visible in OPNsense UI)"),
+  apply: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      "Apply the change immediately by calling reconfigure (default: true). Set false to batch multiple updates.",
+    ),
+});
+
 // ---------------------------------------------------------------------------
 // Tool definitions (for ListTools)
 // ---------------------------------------------------------------------------
@@ -100,7 +135,95 @@ export const systemToolDefinitions = [
       required: ["service_name", "action"],
     },
   },
+  {
+    name: "opnsense_sys_tunable_list",
+    description:
+      "List all configured FreeBSD sysctl tunables on OPNsense (System → Settings → Tunables). Returns tunable name, configured value, UUID, description. Use opnsense_sys_tunable_get to inspect a specific one.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "opnsense_sys_tunable_get",
+    description:
+      "Get a single configured tunable by sysctl name (e.g. 'dev.em.0.eee_control'). Returns the configured value, UUID, and description. Returns null if the tunable is not configured.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        tunable: {
+          type: "string",
+          description:
+            "FreeBSD sysctl name (e.g. 'dev.em.0.eee_control', 'net.inet.tcp.recvspace', 'kern.ipc.somaxconn')",
+        },
+      },
+      required: ["tunable"],
+    },
+  },
+  {
+    name: "opnsense_sys_tunable_set",
+    description:
+      "Upsert a FreeBSD sysctl tunable on OPNsense (creates if missing, updates if existing). Persists across reboots via OPNsense config. By default automatically applies the change via reconfigure. Useful for hardware quirks (e.g. dev.em.0.eee_control=0 to disable EEE), performance tuning, or kernel parameter overrides.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        tunable: {
+          type: "string",
+          description: "FreeBSD sysctl name (e.g. 'dev.em.0.eee_control')",
+        },
+        value: {
+          type: "string",
+          description:
+            "Value to set (numbers and strings are both passed as strings, matching OPNsense API)",
+        },
+        descr: {
+          type: "string",
+          description: "Optional description / rationale (visible in OPNsense UI)",
+        },
+        apply: {
+          type: "boolean",
+          description:
+            "Apply the change immediately by calling reconfigure (default: true). Set false to batch multiple updates and apply later.",
+          default: true,
+        },
+      },
+      required: ["tunable", "value"],
+    },
+  },
 ];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TunableRow {
+  uuid?: string;
+  tunable?: string;
+  value?: string;
+  descr?: string;
+  [key: string]: unknown;
+}
+
+interface SearchTunableResponse {
+  rows?: TunableRow[];
+  total?: number;
+  rowCount?: number;
+  current?: number;
+}
+
+/**
+ * Look up a configured tunable by its FreeBSD sysctl name (e.g. "dev.em.0.eee_control").
+ * Returns the matching row including its UUID, or null if not found.
+ *
+ * OPNsense's searchTunable returns all configured tunables; we filter client-side
+ * because the API has no exact-match-by-name query parameter.
+ */
+async function findTunableByName(
+  client: OPNsenseClient,
+  name: string,
+): Promise<TunableRow | null> {
+  const result = await client.post<SearchTunableResponse>("/system/settings/searchTunable", {});
+  const rows = result.rows ?? [];
+  const match = rows.find((row) => row.tunable === name);
+  return match ?? null;
+}
 
 // ---------------------------------------------------------------------------
 // Tool handler
@@ -156,6 +279,82 @@ export async function handleSystemTool(
           `/core/service/${parsed.action}/${encodeURIComponent(parsed.service_name)}`,
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_sys_tunable_list": {
+        // OPNsense convention: search* endpoints accept POST with optional pagination body.
+        // An empty body returns all rows with default pagination.
+        const result = await client.post("/system/settings/searchTunable", {});
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "opnsense_sys_tunable_get": {
+        const parsed = TunableGetSchema.parse(args);
+        const found = await findTunableByName(client, parsed.tunable);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                found ?? { tunable: parsed.tunable, configured: false, message: "Tunable is not configured (using FreeBSD default)" },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+
+      case "opnsense_sys_tunable_set": {
+        const parsed = TunableSetSchema.parse(args);
+        const existing = await findTunableByName(client, parsed.tunable);
+
+        const body = {
+          tunable: {
+            tunable: parsed.tunable,
+            value: parsed.value,
+            descr: parsed.descr ?? "",
+          },
+        };
+
+        let mutationResult: unknown;
+        let action: "added" | "updated";
+
+        if (existing && typeof existing === "object" && "uuid" in existing && existing.uuid) {
+          action = "updated";
+          mutationResult = await client.post(
+            `/system/settings/setTunable/${encodeURIComponent(String(existing.uuid))}`,
+            body,
+          );
+        } else {
+          action = "added";
+          mutationResult = await client.post("/system/settings/addTunable", body);
+        }
+
+        let applyResult: unknown = null;
+        if (parsed.apply !== false) {
+          applyResult = await client.post("/system/settings/reconfigure");
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  action,
+                  tunable: parsed.tunable,
+                  value: parsed.value,
+                  applied: parsed.apply !== false,
+                  mutation: mutationResult,
+                  apply: applyResult,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
       }
 
       default:

--- a/tests/tools/system.test.ts
+++ b/tests/tools/system.test.ts
@@ -13,8 +13,8 @@ function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
 }
 
 describe('System Tool Definitions', () => {
-  it('exports 7 tool definitions', () => {
-    expect(systemToolDefinitions).toHaveLength(7);
+  it('exports 10 tool definitions', () => {
+    expect(systemToolDefinitions).toHaveLength(10);
   });
 
   it('all tools have opnsense_ prefix', () => {
@@ -131,5 +131,138 @@ describe('handleSystemTool', () => {
     const client = mockClient();
     const result = await handleSystemTool('opnsense_sys_nonexistent', {}, client);
     expect(result.content[0].text).toContain('Unknown');
+  });
+});
+
+describe('handleSystemTool — tunables (#133)', () => {
+  it('lists configured tunables', async () => {
+    const rows = [
+      { uuid: 'aaaa-1111', tunable: 'dev.em.0.eee_control', value: '0', descr: 'EEE off' },
+      { uuid: 'bbbb-2222', tunable: 'net.inet.tcp.recvspace', value: '262144', descr: '' },
+    ];
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ rows, total: 2, rowCount: 2, current: 1 }),
+    });
+
+    const result = await handleSystemTool('opnsense_sys_tunable_list', {}, client);
+    expect(result.content[0].text).toContain('dev.em.0.eee_control');
+    expect(result.content[0].text).toContain('aaaa-1111');
+    expect(client.post).toHaveBeenCalledWith('/system/settings/searchTunable', {});
+  });
+
+  it('gets a configured tunable by name', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({
+        rows: [
+          { uuid: 'aaaa-1111', tunable: 'dev.em.0.eee_control', value: '0', descr: 'EEE off' },
+        ],
+      }),
+    });
+
+    const result = await handleSystemTool(
+      'opnsense_sys_tunable_get',
+      { tunable: 'dev.em.0.eee_control' },
+      client,
+    );
+    expect(result.content[0].text).toContain('aaaa-1111');
+    expect(result.content[0].text).toContain('"value": "0"');
+  });
+
+  it('returns "not configured" sentinel when tunable is missing', async () => {
+    const client = mockClient({
+      post: vi.fn().mockResolvedValue({ rows: [] }),
+    });
+
+    const result = await handleSystemTool(
+      'opnsense_sys_tunable_get',
+      { tunable: 'dev.re.0.eee_disable' },
+      client,
+    );
+    expect(result.content[0].text).toContain('"configured": false');
+    expect(result.content[0].text).toContain('FreeBSD default');
+  });
+
+  it('rejects invalid tunable names', async () => {
+    const client = mockClient();
+    const result = await handleSystemTool(
+      'opnsense_sys_tunable_get',
+      { tunable: 'bad name with spaces' },
+      client,
+    );
+    expect(result.content[0].text).toContain('Error');
+  });
+
+  it('adds a new tunable when not present, then applies', async () => {
+    const post = vi
+      .fn()
+      // 1st call — searchTunable lookup, returns empty (not configured)
+      .mockResolvedValueOnce({ rows: [] })
+      // 2nd call — addTunable
+      .mockResolvedValueOnce({ result: 'saved' })
+      // 3rd call — reconfigure
+      .mockResolvedValueOnce({ status: 'ok' });
+
+    const client = mockClient({ post });
+
+    const result = await handleSystemTool(
+      'opnsense_sys_tunable_set',
+      { tunable: 'dev.re.0.eee_disable', value: '1', descr: 'Disable EEE on Realtek LAN NIC' },
+      client,
+    );
+
+    expect(result.content[0].text).toContain('"action": "added"');
+    expect(result.content[0].text).toContain('"applied": true');
+    expect(post).toHaveBeenNthCalledWith(1, '/system/settings/searchTunable', {});
+    expect(post).toHaveBeenNthCalledWith(2, '/system/settings/addTunable', {
+      tunable: {
+        tunable: 'dev.re.0.eee_disable',
+        value: '1',
+        descr: 'Disable EEE on Realtek LAN NIC',
+      },
+    });
+    expect(post).toHaveBeenNthCalledWith(3, '/system/settings/reconfigure');
+  });
+
+  it('updates an existing tunable when present', async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [
+          { uuid: 'aaaa-1111', tunable: 'dev.em.0.eee_control', value: '1', descr: '' },
+        ],
+      })
+      .mockResolvedValueOnce({ result: 'saved' })
+      .mockResolvedValueOnce({ status: 'ok' });
+
+    const client = mockClient({ post });
+
+    const result = await handleSystemTool(
+      'opnsense_sys_tunable_set',
+      { tunable: 'dev.em.0.eee_control', value: '0' },
+      client,
+    );
+
+    expect(result.content[0].text).toContain('"action": "updated"');
+    expect(post).toHaveBeenNthCalledWith(2, '/system/settings/setTunable/aaaa-1111', {
+      tunable: { tunable: 'dev.em.0.eee_control', value: '0', descr: '' },
+    });
+  });
+
+  it('skips reconfigure when apply=false', async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ result: 'saved' });
+
+    const client = mockClient({ post });
+
+    const result = await handleSystemTool(
+      'opnsense_sys_tunable_set',
+      { tunable: 'kern.ipc.somaxconn', value: '4096', apply: false },
+      client,
+    );
+
+    expect(result.content[0].text).toContain('"applied": false');
+    expect(post).toHaveBeenCalledTimes(2); // search + add, no reconfigure
   });
 });


### PR DESCRIPTION
## Summary

Adds 3 MCP tools for managing FreeBSD sysctl tunables on OPNsense via the System → Settings → Tunables config (persists across reboots).

| Tool | OPNsense API |
|------|--------------|
| \`opnsense_sys_tunable_list\` | POST \`/system/settings/searchTunable\` |
| \`opnsense_sys_tunable_get\` | searchTunable + filter by sysctl name |
| \`opnsense_sys_tunable_set\` | upsert via \`addTunable\` / \`setTunable/{uuid}\` + auto-\`reconfigure\` |

## Why

Closes #133. Currently no MCP path exists to read/write OPNsense tunables. This blocks MCP-first remediation of recurring issues like:

- Intel em / Realtek re EEE/LPI link drops (need \`dev.em.0.eee_control=0\` or driver-equivalent)
- Performance tuning (\`net.inet.tcp.recvspace\`, \`kern.ipc.somaxconn\`)
- Any FreeBSD kernel parameter override

Operators today must fall back to OPNsense UI or SSH — violates the MCP-first principle.

## Design choices

- **Path A** — uses OPNsense REST API (config-side), so values **persist across reboots**. Runtime-only \`sysctl\` shell-out was rejected as it would lose values on reboot.
- **\`set\` is upsert** — creates if missing, updates if existing — matches operator intuition ("ensure this value").
- **Auto-apply via \`reconfigure\` by default** — most callers want immediate effect. \`apply: false\` lets you batch multiple updates.
- **\`get\` returns a friendly sentinel** when the tunable isn't configured (\`{configured: false, message: "Tunable is not configured (using FreeBSD default)"}\`) instead of an empty result that's hard to act on.

## Test plan

- [x] \`npm test\` — 188 tests pass (7 new tunable tests)
- [x] \`npm run build\` — clean tsc
- [x] No \`any\` types, no new runtime deps, all params Zod-validated
- [x] CHANGELOG entry added under \`v2026.05.06.1\`
- [x] README System table updated (7 → 10 tools)
- [x] \`package.json\` + index.ts version bumped to \`2026.5.6-1\`
- [ ] **Live test against bifrost (post-merge)**: read \`dev.em.0.eee_control\` (expect \`0\` per prior fix), then probe \`re\` driver for EEE knobs and apply on LAN-side as needed

## Acceptance Criteria (per linked issue)

- [x] Implements \`system_tunable_list\` returning configured tunables
- [x] Implements \`system_tunable_get\` accepting sysctl name
- [x] Implements \`system_tunable_set\` accepting sysctl name + value (upsert)
- [x] Persists across reboots (config-side, not runtime-only)
- [x] Unit tests cover happy path + edge cases (invalid name, not-configured, skip-apply, add vs update)

## Closes

- #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)