### PR TITLE
fix: dhcp_list_leases / find_lease query Kea backend (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.05.06.2
+
+- **fix: DHCP lease endpoints now return Kea leases on Kea-backed installs** (#131)
+  - `opnsense_dhcp_list_leases` and `opnsense_dhcp_find_lease` previously called only the legacy ISC endpoint `/dhcpv4/leases/searchLease`, which returns empty arrays when Kea is the active DHCPv4 backend (the modern OPNsense default).
+  - Both tools now try Kea (`/kea/leases4/search`) first and fall back to ISC on error (404 / plugin missing) — matching the auto-detect pattern already used for static reservations.
+  - Empty Kea responses (no leases yet) are returned as-is and do **not** trigger the ISC fallback — only actual errors do, so genuinely-empty results stay distinguishable from misconfiguration.
+  - `find_lease` `searchPhrase` is forwarded to whichever backend handles the request.
+  - 9 new vitest unit tests covering: Kea success, ISC fallback on Kea error, empty-but-valid Kea response (no fallback), find by MAC with URL encoding, find fallback, empty-query rejection.
+
 ## v2026.05.06.1
 
 - **feat: System tunables tools** (#133)

--- a/README.md
+++ b/README.md
@@ -457,8 +457,8 @@ spike, empirical findings, and rollback contract.
 
 | Tool | Description |
 |------|-------------|
-| `opnsense_dhcp_list_leases` | List all current DHCPv4 leases |
-| `opnsense_dhcp_find_lease` | Search leases by IP, MAC, or hostname |
+| `opnsense_dhcp_list_leases` | List all current DHCPv4 leases (Kea + ISC, auto-detected) |
+| `opnsense_dhcp_find_lease` | Search leases by IP, MAC, or hostname (Kea + ISC, auto-detected) |
 | `opnsense_dhcp_list_static` | List static DHCP mappings (reservations) |
 | `opnsense_dhcp_add_static` | Add a static DHCP mapping |
 | `opnsense_dhcp_delete_static` | Delete a static mapping by UUID |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "@itunified/mcp-opnsense",
-  "version": "2026.3.13",
+  "name": "@itunified.io/mcp-opnsense",
+  "version": "2026.5.6-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@itunified/mcp-opnsense",
-      "version": "2026.3.13",
-      "license": "MIT",
+      "name": "@itunified.io/mcp-opnsense",
+      "version": "2026.5.6-1",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.0",
         "axios": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified.io/mcp-opnsense",
-  "version": "2026.5.6-1",
+  "version": "2026.5.6-2",
   "description": "Slim OPNsense MCP Server — DNS, Firewall, Diagnostics, DHCP, System management via OPNsense REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ for (const def of tailscaleToolDefinitions) toolHandlers.set(def.name, handleTai
 for (const def of natToolDefinitions) toolHandlers.set(def.name, handleNatTool);
 
 const server = new Server(
-  { name: 'mcp-opnsense', version: '2026.5.6-1' },
+  { name: 'mcp-opnsense', version: '2026.5.6-2' },
   { capabilities: { tools: {} } }
 );
 

--- a/src/tools/dhcp.ts
+++ b/src/tools/dhcp.ts
@@ -78,12 +78,14 @@ async function detectDhcpBackend(client: OPNsenseClient): Promise<DhcpBackend> {
 export const dhcpToolDefinitions = [
   {
     name: "opnsense_dhcp_list_leases",
-    description: "List all current DHCPv4 leases",
+    description:
+      "List all current DHCPv4 leases. Supports both Kea DHCP (default on modern OPNsense) and ISC DHCP (legacy) backends — auto-detects which is active.",
     inputSchema: { type: "object" as const, properties: {} },
   },
   {
     name: "opnsense_dhcp_find_lease",
-    description: "Search DHCPv4 leases by IP address, MAC address, or hostname",
+    description:
+      "Search DHCPv4 leases by IP address, MAC address, or hostname. Supports both Kea DHCP and ISC DHCP (legacy) backends — auto-detects which is active.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -351,8 +353,40 @@ async function keaApply(
 }
 
 // ---------------------------------------------------------------------------
+// Kea DHCP lease helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * List Kea DHCPv4 leases. After OPNsense's Kea migration, leases live in
+ * /var/db/kea/kea-leases4.csv and are exposed via the Kea Leases plugin
+ * endpoint `/kea/leases4/search` — NOT the legacy `/dhcpv4/leases/searchLease`
+ * (which only returns ISC dhcpd leases and is empty under Kea).
+ *
+ * Returns an OPNsense-standard search response: `{rows, rowCount, total, current}`.
+ */
+async function keaListLeases(client: OPNsenseClient): Promise<unknown> {
+  return await client.get("/kea/leases4/search");
+}
+
+async function keaFindLease(client: OPNsenseClient, query: string): Promise<unknown> {
+  return await client.get(
+    `/kea/leases4/search?searchPhrase=${encodeURIComponent(query)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
 // ISC DHCP helpers (legacy)
 // ---------------------------------------------------------------------------
+
+async function iscListLeases(client: OPNsenseClient): Promise<unknown> {
+  return await client.get("/dhcpv4/leases/searchLease");
+}
+
+async function iscFindLease(client: OPNsenseClient, query: string): Promise<unknown> {
+  return await client.get(
+    `/dhcpv4/leases/searchLease?searchPhrase=${encodeURIComponent(query)}`,
+  );
+}
 
 async function iscListStatic(
   client: OPNsenseClient,
@@ -396,16 +430,29 @@ export async function handleDhcpTool(
   try {
     switch (name) {
       case "opnsense_dhcp_list_leases": {
-        const result = await client.get("/dhcpv4/leases/searchLease");
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        // Try Kea first (the modern OPNsense default). If Kea endpoint 404s
+        // (plugin not installed) fall back to ISC dhcpd. This matches the
+        // backend-detection pattern used for static reservations and fixes
+        // #131 — without this, Kea-backed installs returned empty arrays
+        // even when active leases were visible in the OPNsense UI.
+        try {
+          const result = await keaListLeases(client);
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } catch {
+          const result = await iscListLeases(client);
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        }
       }
 
       case "opnsense_dhcp_find_lease": {
         const parsed = FindLeaseSchema.parse(args);
-        const result = await client.get(
-          `/dhcpv4/leases/searchLease?searchPhrase=${encodeURIComponent(parsed.query)}`,
-        );
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        try {
+          const result = await keaFindLease(client, parsed.query);
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } catch {
+          const result = await iscFindLease(client, parsed.query);
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        }
       }
 
       case "opnsense_dhcp_list_static": {

--- a/tests/tools/dhcp.test.ts
+++ b/tests/tools/dhcp.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+import { dhcpToolDefinitions, handleDhcpTool } from '../../src/tools/dhcp.js';
+import type { OPNsenseClient } from '../../src/client/opnsense-client.js';
+
+function mockClient(overrides: Partial<OPNsenseClient> = {}): OPNsenseClient {
+  return {
+    get: vi.fn().mockResolvedValue({ rows: [] }),
+    post: vi.fn().mockResolvedValue({ status: 'ok' }),
+    delete: vi.fn().mockResolvedValue({ status: 'ok' }),
+    getRaw: vi.fn().mockResolvedValue(''),
+    ...overrides,
+  } as unknown as OPNsenseClient;
+}
+
+describe('DHCP Tool Definitions', () => {
+  it('exports tool definitions', () => {
+    expect(dhcpToolDefinitions.length).toBeGreaterThanOrEqual(11);
+  });
+
+  it('all tools have opnsense_ prefix', () => {
+    for (const tool of dhcpToolDefinitions) {
+      expect(tool.name).toMatch(/^opnsense_/);
+    }
+  });
+
+  it('lease tool descriptions mention Kea fallback', () => {
+    const list = dhcpToolDefinitions.find((t) => t.name === 'opnsense_dhcp_list_leases');
+    const find = dhcpToolDefinitions.find((t) => t.name === 'opnsense_dhcp_find_lease');
+    expect(list?.description).toMatch(/Kea/);
+    expect(find?.description).toMatch(/Kea/);
+  });
+});
+
+describe('handleDhcpTool — list_leases (#131)', () => {
+  it('returns Kea leases when the Kea endpoint succeeds', async () => {
+    const keaRows = [
+      { address: '10.0.0.100', hwaddr: 'aa:bb:cc:dd:ee:ff', state: 'active' },
+      { address: '10.0.0.101', hwaddr: 'aa:bb:cc:dd:ee:00', state: 'active' },
+    ];
+    const get = vi.fn(async (path: string) => {
+      if (path === '/kea/leases4/search') return { rows: keaRows, total: 2 };
+      throw new Error(`unexpected path: ${path}`);
+    });
+    const client = mockClient({ get });
+
+    const result = await handleDhcpTool('opnsense_dhcp_list_leases', {}, client);
+    expect(result.content[0].text).toContain('10.0.0.100');
+    expect(result.content[0].text).toContain('aa:bb:cc:dd:ee:ff');
+    expect(get).toHaveBeenCalledWith('/kea/leases4/search');
+  });
+
+  it('falls back to ISC when Kea endpoint throws (plugin not installed)', async () => {
+    const get = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('GET /kea/leases4/search: 404 Not Found'))
+      .mockResolvedValueOnce({ rows: [{ address: '192.168.1.50', mac: 'bb:cc:dd:ee:ff:00' }] });
+    const client = mockClient({ get });
+
+    const result = await handleDhcpTool('opnsense_dhcp_list_leases', {}, client);
+    expect(result.content[0].text).toContain('192.168.1.50');
+    expect(get).toHaveBeenNthCalledWith(1, '/kea/leases4/search');
+    expect(get).toHaveBeenNthCalledWith(2, '/dhcpv4/leases/searchLease');
+  });
+
+  it('returns Kea result even when rows are empty (no fallback)', async () => {
+    // Important: empty rows is a valid Kea response (no leases yet) and
+    // MUST NOT trigger the ISC fallback. Only an actual error should.
+    const get = vi.fn().mockResolvedValueOnce({ rows: [], total: 0 });
+    const client = mockClient({ get });
+
+    const result = await handleDhcpTool('opnsense_dhcp_list_leases', {}, client);
+    expect(result.content[0].text).toContain('"total": 0');
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith('/kea/leases4/search');
+  });
+});
+
+describe('handleDhcpTool — find_lease (#131)', () => {
+  it('searches Kea by query and forwards searchPhrase', async () => {
+    const get = vi.fn().mockResolvedValueOnce({
+      rows: [{ address: '10.0.0.100', hwaddr: 'aa:bb:cc:dd:ee:ff' }],
+    });
+    const client = mockClient({ get });
+
+    const result = await handleDhcpTool(
+      'opnsense_dhcp_find_lease',
+      { query: 'aa:bb:cc:dd:ee:ff' },
+      client,
+    );
+    expect(result.content[0].text).toContain('10.0.0.100');
+    expect(get).toHaveBeenCalledWith(
+      '/kea/leases4/search?searchPhrase=aa%3Abb%3Acc%3Add%3Aee%3Aff',
+    );
+  });
+
+  it('falls back to ISC searchLease when Kea search throws', async () => {
+    const get = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Kea not available'))
+      .mockResolvedValueOnce({ rows: [{ address: '192.168.1.50' }] });
+    const client = mockClient({ get });
+
+    const result = await handleDhcpTool(
+      'opnsense_dhcp_find_lease',
+      { query: '192.168.1.50' },
+      client,
+    );
+    expect(result.content[0].text).toContain('192.168.1.50');
+    expect(get).toHaveBeenNthCalledWith(2, '/dhcpv4/leases/searchLease?searchPhrase=192.168.1.50');
+  });
+
+  it('rejects empty query', async () => {
+    const client = mockClient();
+    const result = await handleDhcpTool('opnsense_dhcp_find_lease', { query: '' }, client);
+    expect(result.content[0].text).toContain('Error');
+  });
+});


### PR DESCRIPTION
## Summary

Both \`opnsense_dhcp_list_leases\` and \`opnsense_dhcp_find_lease\` previously called only the legacy ISC endpoint \`/dhcpv4/leases/searchLease\`, which returns empty arrays when Kea is the active DHCPv4 backend (the modern OPNsense default). Operators saw no leases via MCP even though the OPNsense UI showed many.

## Fix

Both tools now try Kea (\`/kea/leases4/search\`) first and fall back to ISC on error (404 / plugin missing) — matching the auto-detect pattern already used for \`opnsense_dhcp_{list,add,delete}_static\`.

**Empty Kea responses are returned as-is and do NOT trigger fallback** — only actual errors do, so genuinely-empty results stay distinguishable from misconfiguration.

## Verified by tests

| Test case | Validates |
|-----------|-----------|
| Kea returns rows | normal Kea-active path |
| Kea throws 404 | ISC fallback fires correctly |
| Kea returns \`{rows: [], total: 0}\` | empty-but-valid → **no** fallback (single API call) |
| find_lease MAC search | URL-encoded \`searchPhrase\` forwarded |
| find_lease Kea throw | fallback uses ISC searchPhrase |
| find_lease empty query | Zod rejection unchanged |

## Test plan

- [x] \`npm test\` — 197 tests pass (9 new dhcp tests)
- [x] \`npm run build\` — clean tsc
- [x] CHANGELOG entry under \`v2026.05.06.2\`
- [x] README updated to reflect Kea+ISC auto-detect for lease tools
- [x] \`package.json\` + \`index.ts\` version bumped to \`2026.5.6-2\`
- [ ] **Live test against bifrost (post-merge + restart)**: \`opnsense_dhcp_list_leases\` should return ~14 active LAN leases (matches \`opnsense_diag_arp_table interface=re0\`)

## Acceptance Criteria

- [x] Lease list returns Kea leases on Kea-backed installs
- [x] ISC-only installs continue to work via fallback
- [x] Empty-but-valid Kea response is preserved (does not silently return ISC empty)
- [x] Unit tests for both backends + edge cases

## Closes

- #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)